### PR TITLE
Docs: análisis de viabilidad arquitectónica y hoja de ruta detallada

### DIFF
--- a/ARCHITECTURE_ANALYSIS.md
+++ b/ARCHITECTURE_ANALYSIS.md
@@ -1,0 +1,134 @@
+# Análisis de Arquitectura y Viabilidad — Ligero Framework
+
+> **Fecha:** 2026-07-04 · **Versión analizada:** `0.1.0-SNAPSHOT` (commit `bb9417f`)
+> Este documento es el diagnóstico técnico que fundamenta la hoja de ruta ([ROADMAP.md](ROADMAP.md)).
+
+## 1. Resumen ejecutivo
+
+Ligero es un micro-framework web para Java 21 con una API fluida inspirada en Express.js. La idea es viable y tiene un nicho real (alternativa ligera a Spring Boot, competencia de Javalin/Spark/Micronaut para APIs pequeñas), pero **el estado actual no es publicable**: hay bugs funcionales en features anunciadas en el README, cero tests, cero CI, dependencias incorrectas y decisiones de build que romperían a cualquier consumidor del artefacto.
+
+**Veredicto de viabilidad:** viable como proyecto, **no viable en su estado actual** como dependencia de terceros. Las fases 0 y 1 del roadmap son condición necesaria para cualquier release público.
+
+## 2. Estado actual
+
+### 2.1 Estructura de módulos
+
+```
+ligero/
+├── core/      ← VACÍO (solo build.gradle, sin una sola clase)
+├── http/      ← Interfaces HttpRequest, HttpResponse, HttpHandler, WrappedHttpRequest
+├── router/    ← Router (matching de rutas + dispatch)
+├── json/      ← Utilidad Json (wrapper de Jackson)
+├── server/    ← HttpServer (adapter de com.sun.net.httpserver) + fachada Ligero
+└── examples/  ← ExampleApp
+```
+
+**Grafo de dependencias actual (con problemas señalados):**
+
+```
+server ──► core (vacío ⚠)
+server ──► http, router, json
+router ──► http, javalin 5.5.0 (⚠ SIN USAR — arrastra Jetty completo)
+http   ──► json (⚠ acoplamiento innecesario), com.sun.net.httpserver:http:20070405 (⚠ artefacto de 2007, la clase ya viene en el JDK)
+json   ──► jackson-databind 2.14.2 (⚠ desactualizado, CVEs conocidas)
+```
+
+### 2.2 Inventario de código
+
+~1.200 líneas de Java en 11 archivos. Sin tests (`src/test` no existe en ningún módulo). Sin CI (no hay `.github/workflows`). Sin `module-info.java`. Sin archivo `LICENSE` (el README lo enlaza). Documentación mixta español/inglés; `ROUTE.md` y `TO_REVIEW.md` son notas pegadas de conversaciones, no documentación del proyecto.
+
+## 3. Bugs y defectos encontrados (bloqueantes de release)
+
+| # | Severidad | Defecto | Ubicación |
+|---|-----------|---------|-----------|
+| B1 | **Crítica** | **Los path params `{id}` no funcionan.** `Router.handle` solo inyecta parámetros si `request instanceof WrappedHttpRequest`, pero `HttpServer` pasa `SunHttpRequest` directamente, así que `req.getPathParams()` siempre devuelve el mapa vacío del `default` de la interfaz. La feature estrella del README está rota. | `router/Router.java:228`, `server/HttpServer.java:68` |
+| B2 | **Crítica** | `--enable-preview` global en compilación. Los `.class` publicados quedan marcados como preview y **ningún consumidor podría usarlos** sin activar preview en su propia JVM, además de atarse a la versión exacta del JDK. No se usa ninguna API preview en el código. | `build.gradle:44` |
+| B3 | Alta | `redirect()` envía headers con 302 fijo sin comprobar `headersSent`, ignora `status()` previo y deja el flag inconsistente; llamado tras un `send()` lanza `IOException` envuelta en `RuntimeException`. | `server/SunHttpResponse.java` |
+| B4 | Alta | Regex de normalización incorrecta: `path.replaceAll("//+/", "/")` no colapsa `//` dobles (solo secuencias de 3+). `GET //users` no matchea `/users`. | `router/Router.java:272` |
+| B5 | Alta | Pool de hilos fijo (`newFixedThreadPool(nProcs)`) sobre I/O bloqueante: bajo carga, N requests lentas saturan el servidor. En Java 21 lo correcto es `newVirtualThreadPerTaskExecutor()` (Loom), que además es la premisa declarada del proyecto en `ROUTE.md`. | `server/HttpServer.java:49` |
+| B6 | Alta | ~40 `System.out.println` de debug en el hot path (cada request imprime ~10 líneas). Contamina stdout del usuario y degrada rendimiento. No hay abstracción de logging. | `Router.java`, `Ligero.java`, `SunHttpRequest.java` |
+| B7 | Media | Headers HTTP tratados como case-sensitive (`HashMap` en `getHeaders()`); RFC 9110 exige case-insensitive. Además el mapa se reconstruye en cada llamada. | `server/SunHttpRequest.java` |
+| B8 | Media | Sin límite de tamaño de body ni timeouts de lectura → DoS trivial con un body infinito. | `server/SunHttpRequest.java` (`getBodyAsString`) |
+| B9 | Media | Query param sin valor inserta `null` en el mapa (`params.put(key, null)`) → NPE latente para el usuario. | `server/SunHttpRequest.java` |
+| B10 | Media | `artifactId` publicados serían `core`, `http`, `json`, `router`, `server` (nombres genéricos sin prefijo). El README promete `ligero-core`. Colisión/rechazo garantizado en Maven Central. | `settings.gradle`, `build.gradle` |
+| B11 | Media | `examples` genera un fat-jar que re-empaqueta todas las dependencias con `maven-publish` aplicado → publicaría un uber-jar accidentalmente. | `examples/build.gradle` |
+| B12 | Baja | `json/build.gradle` re-declara `group`/`version` hardcodeados (`0.1.0` vs `0.1.0-SNAPSHOT` del root) → versiones inconsistentes entre módulos. | `json/build.gradle` |
+| B13 | Baja | URL de publicación `s01.oss.sonatype.org` (OSSRH) — servicio retirado en 2025; hay que migrar a Central Portal. | `build.gradle` |
+| B14 | Baja | README anuncia badge de Maven Central y versión `0.1.0` que no existen; instrucciones de instalación no funcionales. | `README.md` |
+
+## 4. Evaluación SOLID
+
+### SRP — Responsabilidad Única: ✗
+- `Router` mezcla 4 responsabilidades: registro de rutas, algoritmo de matching, normalización de paths y dispatch/manejo de errores. `Route.matches` además muta el mapa de params como efecto lateral.
+- `Ligero` (fachada) también normaliza paths y decide política de 404 — lógica duplicada con `Router`.
+- La normalización de `contextPath`/paths está **triplicada** (`Ligero`, `HttpServer`, `Router`), con implementaciones ligeramente distintas (violación DRY que ya produjo B4).
+
+### OCP — Abierto/Cerrado: ✗
+- No existe ningún punto de extensión: ni middleware, ni plugins, ni SPI. Añadir CORS, auth o logging exige modificar el core.
+- Métodos HTTP hardcodeados como métodos separados (`get/post/put/delete`); soportar `PATCH`, `HEAD`, `OPTIONS` requiere tocar `Router` y `Ligero`.
+
+### LSP — Sustitución de Liskov: ✗
+- El contrato de `HttpRequest` se rompe según la implementación: los path params solo funcionan con `WrappedHttpRequest` (chequeo `instanceof` en `Router.handle`). Un `HttpRequest` cualquiera no es sustituible — causa directa del bug B1. La interfaz debería exponer los params sin depender del tipo concreto.
+
+### ISP — Segregación de Interfaces: ✓ (aceptable)
+- `HttpRequest`, `HttpResponse` y `HttpHandler` son pequeñas y cohesivas. Punto a favor del diseño actual.
+
+### DIP — Inversión de Dependencias: ✗
+- `Ligero` instancia `HttpServer` concreto con `new` (acoplado a `com.sun.net.httpserver`). No existe una abstracción `ServerEngine` que permita cambiar de motor (Jetty, Netty, JDK) ni inyectar uno de pruebas.
+- La clase pública principal `Ligero` vive en el módulo `server` (capa de infraestructura) mientras `core` está vacío: **la dependencia apunta al revés**. La API debería estar en `core` y `server` ser un detalle enchufable.
+- `http` depende de `json`: las abstracciones dependen de un detalle de serialización.
+
+## 5. Escalabilidad
+
+| Aspecto | Estado | Problema |
+|---|---|---|
+| Concurrencia | ✗ | Thread pool fijo = techo de `nProcs` requests simultáneas con I/O bloqueante (B5). |
+| Matching de rutas | ✗ | Búsqueda lineal O(n) por request; con 500 rutas se degrada. Se necesita trie/árbol de segmentos. |
+| Memoria por request | ✗ | Reconstrucción de headers en cada `getHeaders()`, prints de debug, splits repetidos de la misma ruta. |
+| Backpressure / límites | ✗ | Sin límite de body, sin timeouts, sin límite de conexiones. |
+| Observabilidad | ✗ | Sin logging estructurado, sin métricas, sin health checks — inoperable en producción. |
+| Escalado horizontal | ✓ | El framework es stateless por diseño; no hay bloqueos aquí. |
+
+## 6. Arquitectura objetivo
+
+Principios: la API en `core`, los detalles en adapters; todo punto de variación detrás de una interfaz con implementación por defecto; cero dependencias externas en `core` (Jackson solo en `ligero-json`, motores de servidor solo en sus adapters).
+
+```
+                    ┌────────────────────────────┐
+   usuario ───────► │  ligero-core (API pública) │
+                    │  App, Router, Middleware,  │
+                    │  Context(Req/Res), Config, │
+                    │  ExceptionHandler, SPIs    │
+                    └─────────────┬──────────────┘
+                                  │ SPIs (ServiceLoader / inyección)
+        ┌────────────────┬────────┴───────┬───────────────────┐
+        ▼                ▼                ▼                   ▼
+ ligero-server-jdk  ligero-json     ligero-template-*   ligero-plugins-*
+ (com.sun.net,      (Jackson;       (mustache, etc.)    (cors, static,
+  virtual threads)   BodyMapper SPI)                     auth, metrics…)
+        ▼
+ ligero-server-jetty / -netty (futuro, mismo SPI)
+```
+
+Decisiones clave:
+1. **`ServerEngine` como SPI** (DIP): `core` define `interface ServerEngine { void start(HandlerPipeline p); void stop(Duration grace); }`; el adapter JDK con virtual threads es la implementación por defecto vía `ServiceLoader`.
+2. **Middleware como composición de funciones** (OCP): `interface Middleware { void handle(Context ctx, Next next); }` — todo lo transversal (CORS, auth, logging, compresión, static files) se implementa como middleware, nunca en el core.
+3. **`Context` único** en lugar de pares `(req, res)`: simplifica firma de handlers y middleware, y da un solo lugar para atributos por-request (con `ScopedValue` de Java 21 para el contexto implícito).
+4. **Un único `PathNormalizer` y un `RouteTrie`** en `core`: una sola fuente de verdad para normalización y matching O(longitud-del-path).
+5. **`BodyMapper` SPI**: `http`/`core` no conocen Jackson; `ligero-json` registra la implementación.
+6. **Errores como jerarquía propia** (`LigeroException`, `HttpException(status)`) + `ExceptionHandler` registrable; nunca `RuntimeException` genéricas ni stack traces al cliente.
+
+## 7. Comparativa de mercado (para enfocar el nicho)
+
+| | Ligero (objetivo) | Javalin | Spark | Spring Boot |
+|---|---|---|---|---|
+| Dependencias del core | 0 | Jetty | Jetty | decenas |
+| Arranque | < 100 ms | ~300 ms | ~300 ms | 2–10 s |
+| Virtual threads nativos | ✓ (diferenciador) | opcional | ✗ | opcional |
+| Curva de aprendizaje | minutos | minutos | minutos | semanas |
+
+El diferenciador defendible es: **cero dependencias en el core + virtual threads por defecto + API en español/inglés bien documentada**. Sin tests ni estabilidad de API, ninguna de esas ventajas importa: la fase 0 del roadmap es prerequisito de todo lo demás.
+
+## 8. Conclusión
+
+Prioridad absoluta: **corregir antes que crecer**. El detalle accionable, con fases, criterios de aceptación y estimaciones, está en [ROADMAP.md](ROADMAP.md).

--- a/FRAMEWORK_IMPROVEMENTS.md
+++ b/FRAMEWORK_IMPROVEMENTS.md
@@ -1,3 +1,5 @@
+> **⚠️ Documento histórico.** Estas notas iniciales fueron consolidadas en la hoja de ruta oficial: ver [ROADMAP.md](ROADMAP.md) y [ARCHITECTURE_ANALYSIS.md](ARCHITECTURE_ANALYSIS.md).
+
 # Ligero Framework Improvement Suggestions
 
 Based on the current state of the Ligero Framework, here are several improvements that could enhance its functionality, usability, and adoption.

--- a/README.md
+++ b/README.md
@@ -188,14 +188,13 @@ Check out the [examples directory](examples/src/main/java/com/ligero/examples) f
 
 ## Roadmap
 
-- [ ] Middleware support
-- [ ] WebSocket support
-- [ ] Static file serving
-- [ ] Template engine integration
-- [ ] Form data parsing
-- [ ] CORS support
-- [ ] Authentication helpers
-- [ ] OpenAPI/Swagger integration
+The detailed, phased roadmap lives in [ROADMAP.md](ROADMAP.md), backed by the technical assessment in [ARCHITECTURE_ANALYSIS.md](ARCHITECTURE_ANALYSIS.md). Highlights:
+
+- **Phase 0 (v0.2)** — Stabilization: bug fixes, dependency cleanup, tests, CI
+- **Phase 1 (v0.3)** — Extensible core: middleware chain, server/JSON SPIs, trie-based router
+- **Phase 2 (v0.4)** — Web essentials: static files, CORS, templates, validation, config
+- **Phase 3 (v0.5)** — Production readiness: security, observability, WebSockets
+- **Phase 4 (v0.6–1.0)** — Ecosystem: testing utilities, OpenAPI, CLI, API freeze
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,194 @@
+# Hoja de Ruta — Ligero Framework
+
+> **Documento canónico de la hoja de ruta.** Sustituye y consolida las notas previas de `ROUTE.md` y `FRAMEWORK_IMPROVEMENTS.md`.
+> El diagnóstico técnico que justifica cada fase está en [ARCHITECTURE_ANALYSIS.md](ARCHITECTURE_ANALYSIS.md).
+> Última actualización: 2026-07-04.
+
+## Visión
+
+Micro-framework web para Java 21+ con **cero dependencias en el core**, **virtual threads por defecto** y una API expresiva estilo Express. Objetivo 1.0: que un desarrollador construya y despliegue una API REST productiva en menos de 10 minutos, con un jar final < 5 MB.
+
+## Reglas de arquitectura (aplican a todas las fases)
+
+1. **DIP:** la API pública vive en `ligero-core`; motores de servidor, JSON y templates son adapters detrás de SPIs (`ServerEngine`, `BodyMapper`, `TemplateEngine`) resueltos por `ServiceLoader` o inyección explícita.
+2. **OCP:** toda funcionalidad transversal (CORS, auth, static files, compresión, métricas) se implementa como `Middleware`, nunca modificando el core.
+3. **SRP/DRY:** una sola clase para normalización de paths (`PathNormalizer`), una para matching (`RouteTrie`). Prohibido duplicar esa lógica.
+4. **LSP:** los contratos de `HttpRequest`/`HttpResponse`/`Context` no dependen de la implementación concreta (nada de `instanceof` para activar features).
+5. **Sin dependencias externas en `ligero-core`.** Jackson solo en `ligero-json`; SLF4J-API es la única excepción permitida.
+6. Todo cambio entra con tests; cobertura mínima 80 % en `core`, `http`, `router`.
+7. API pública documentada con Javadoc en inglés (docs de usuario en inglés y español).
+
+---
+
+## Fase 0 — Estabilización (v0.2.0) — **bloqueante para cualquier release**
+
+**Objetivo:** que lo que ya existe funcione, compile limpio y sea consumible como dependencia.
+**Esfuerzo estimado:** 2–3 semanas · **Prioridad:** crítica
+
+### 0.1 Corrección de bugs (referencias en ARCHITECTURE_ANALYSIS.md §3)
+
+- [ ] **B1 — Path params rotos:** eliminar el chequeo `instanceof WrappedHttpRequest` en `Router.handle`; el router construye el request con params y lo pasa al handler (o `Context` mutable en Fase 1). Test de regresión end-to-end: `GET /users/42` debe devolver `id=42` a través del servidor real.
+- [ ] **B2 — Quitar `--enable-preview`** de compilación, tests y `JavaExec` (no se usa ninguna API preview). Verificar que los `.class` publicados no llevan flag preview.
+- [ ] **B3 — `redirect()`:** respetar `headersSent`, permitir 301/303/307/308 (`redirect(String url, int status)`), no pisar `status()` sin avisar.
+- [ ] **B4 — Normalización:** regex correcta (`/{2,}` → `/`) y centralizada en una utilidad única `PathNormalizer` usada por `Ligero`, `Router` y `HttpServer` (elimina la triplicación).
+- [ ] **B5 — Virtual threads:** `Executors.newVirtualThreadPerTaskExecutor()` como executor por defecto; pool fijo solo como opción explícita.
+- [ ] **B7 — Headers case-insensitive** (`TreeMap(String.CASE_INSENSITIVE_ORDER)`), calculados una vez y cacheados; exponer multi-valor (`getHeaderValues(name)`).
+- [ ] **B8 — Límite de body configurable** (default 10 MB → `413 Payload Too Large`) y timeouts de lectura.
+- [ ] **B9 — Query params sin valor** → `""` en lugar de `null`; soportar claves repetidas (`getQueryParams(name) → List<String>`).
+
+### 0.2 Higiene de dependencias y build
+
+- [ ] Eliminar `io.javalin:javalin` de `router` (sin usar; arrastra Jetty completo — contradice "ligero").
+- [ ] Eliminar `com.sun.net.httpserver:http:20070405` de `http` (la clase viene en el JDK) y la dependencia `http → json`.
+- [ ] Actualizar Jackson a la última 2.x estable; gestionar versiones con *version catalog* (`gradle/libs.versions.toml`).
+- [ ] Renombrar artefactos publicados a `ligero-core`, `ligero-http`, `ligero-router`, `ligero-json`, `ligero-server` (en `settings.gradle` o `archivesName`); alinear con el README.
+- [ ] `examples`: excluir de `maven-publish` y del pipeline de release; eliminar `group/version` hardcodeados en `json/build.gradle` (B11, B12).
+- [ ] Migrar publicación de OSSRH (`s01.oss.sonatype.org`, retirado) al **Central Portal** de Sonatype (B13).
+- [ ] Añadir archivo `LICENSE` (Apache 2.0) — el README ya lo enlaza.
+
+### 0.3 Logging
+
+- [ ] Sustituir los ~40 `System.out.println` por **SLF4J-API** (niveles `debug`/`trace` para el matching de rutas); `slf4j-simple` solo en `examples` y tests (B6).
+
+### 0.4 Tests y CI
+
+- [ ] Tests unitarios: `Router` (matching exacto, params, raíz, contexto, colisiones, orden de registro), `PathNormalizer`, `Json`, `SunHttpRequest/Response` (con mocks de `HttpExchange`).
+- [ ] Tests de integración: servidor real en puerto efímero + `java.net.http.HttpClient` (GET/POST/PUT/DELETE, 404, 500, redirect, query params, path params, body grande, concurrencia básica).
+- [ ] Cobertura con JaCoCo, umbral 80 % en `core/http/router`.
+- [ ] GitHub Actions: build + test en JDK 21 y 25 (Linux) en cada PR; job de publicación de snapshots en `main`.
+- [ ] README: corregir instalación (versión real, sin badge de Maven Central hasta publicar), documentar la limitación de path params corregida.
+
+**Criterio de salida de fase:** `./gradlew build` verde en CI, ejemplo del README funcionando tal cual está escrito, artefactos `ligero-*` instalables desde un repositorio de snapshots.
+
+---
+
+## Fase 1 — Núcleo extensible y SOLID (v0.3.0)
+
+**Objetivo:** reorganizar la arquitectura para que crecer no exija tocar el core.
+**Esfuerzo estimado:** 4–6 semanas · **Prioridad:** alta
+
+### 1.1 Reorganización de módulos (DIP)
+
+- [ ] Mover la fachada `Ligero` y la API pública a `ligero-core` (hoy `core` está vacío y `Ligero` vive en `server`).
+- [ ] Definir SPI `ServerEngine` en `core`; `ligero-server` pasa a ser `ligero-server-jdk`, implementación por defecto descubierta vía `ServiceLoader`.
+- [ ] Definir SPI `BodyMapper` en `core`; `ligero-json` registra la implementación Jackson. `res.json()`/`req.body(Class)` fallan con mensaje claro si no hay mapper en el classpath.
+- [ ] `module-info.java` en todos los módulos (JPMS): exportar solo la API, `provides/uses` para las SPIs.
+
+### 1.2 Middleware (OCP — la pieza más importante del framework)
+
+- [ ] `interface Middleware { void handle(Context ctx, Next next); }` con cadena componible: `app.use(mw)`, `app.use("/api", mw)`, middleware por ruta.
+- [ ] Orden determinista, corte de cadena (no llamar `next`), y hooks `before`/`after`.
+- [ ] Middlewares incluidos de serie: request-logging, request-id.
+
+### 1.3 API de request/response unificada
+
+- [ ] Introducir `Context` (envuelve request+respuesta, atributos por-request, `ScopedValue` para acceso implícito). Mantener la firma `(req, res)` como sobrecarga para no romper la API existente.
+- [ ] Soporte completo de métodos: `PATCH`, `HEAD`, `OPTIONS`, `app.route(method, path, h)`, y `app.any(path, h)`.
+- [ ] Grupos de rutas: `app.group("/api/v1", g -> { g.get(...); })` (elimina el hack actual del contextPath).
+- [ ] Wildcards y splat: `/files/*path`; parámetros tipados `ctx.pathParamAsInt("id")` con 400 automático si no parsea.
+- [ ] Cookies (lectura/escritura, atributos SameSite/HttpOnly/Secure), form data (`application/x-www-form-urlencoded` y `multipart/form-data`), content negotiation básica (`Accept`).
+
+### 1.4 Manejo de errores (SRP)
+
+- [ ] Jerarquía `HttpException(status, message)` + `app.exception(Class<T>, handler)` + `app.error(404, handler)`.
+- [ ] Por defecto: JSON de error uniforme, **sin stack trace al cliente** (hoy `e.getMessage()` se envía en el 500 — fuga de información), stack trace al log.
+
+### 1.5 Router escalable
+
+- [ ] Sustituir la búsqueda lineal O(n) por un **trie de segmentos** (O(longitud del path)); prioridad estático > parámetro > wildcard.
+- [ ] Benchmark JMH del matching (base para no regresionar).
+
+**Criterio de salida:** un plugin de terceros (p. ej. un middleware CORS externo) puede añadirse sin modificar ni recompilar el core; `examples` migrado a la nueva API.
+
+---
+
+## Fase 2 — Funcionalidad web esencial (v0.4.0)
+
+**Objetivo:** cubrir lo que cualquier app web real necesita, todo como middleware/plugins.
+**Esfuerzo estimado:** 4–6 semanas · **Prioridad:** alta
+
+- [ ] **Static files:** `app.staticFiles("/static", Location.CLASSPATH | EXTERNAL)`, con ETag, `Cache-Control` y protección path-traversal (tests de seguridad obligatorios).
+- [ ] **CORS:** middleware configurable (orígenes, métodos, headers, credentials, preflight, `maxAge`).
+- [ ] **Compresión:** gzip por `Accept-Encoding`, umbral mínimo configurable.
+- [ ] **Templates:** SPI `TemplateEngine` + `ctx.render("view", model)`; primer adapter `ligero-template-mustache` (JMustache, dependencia mínima).
+- [ ] **Validación:** helpers `ctx.bodyValidator(Class).check(...)` → 400 con detalle de campos.
+- [ ] **Configuración:** `LigeroConfig` tipado (records) cargable de properties/env-vars con precedencia documentada; `Ligero.create(cfg)`.
+- [ ] **DI opcional (no obligatorio):** registro simple `app.register(Interface.class, impl)` / `ctx.get(Interface.class)`. Sin reflexión mágica ni classpath scanning — coherente con la filosofía "ligero".
+- [ ] Graceful shutdown real: drenaje de conexiones en curso con deadline configurable, hook automático opcional (`app.start()` registra shutdown hook).
+
+**Criterio de salida:** se puede construir una web app completa (HTML + formularios + API JSON + assets) solo con módulos `ligero-*`.
+
+---
+
+## Fase 3 — Producción: seguridad y observabilidad (v0.5.0)
+
+**Objetivo:** operable y defendible en producción.
+**Esfuerzo estimado:** 5–8 semanas · **Prioridad:** media-alta
+
+### Seguridad
+- [ ] Middleware de security headers (`X-Content-Type-Options`, `X-Frame-Options`, HSTS, CSP configurable).
+- [ ] Auth: `ligero-auth` con Basic, Bearer/JWT (verificación; firma delegada a lib estándar) y hooks `app.before` con roles (`ctx.requireRole(...)`).
+- [ ] CSRF para formularios (token por sesión, middleware).
+- [ ] Rate limiting simple en memoria (token bucket) como middleware, con SPI para stores externos.
+- [ ] Sesiones opcionales (cookie firmada; SPI `SessionStore`).
+- [ ] `SECURITY.md` + análisis de dependencias en CI (Dependabot ya activo + `dependency-check` o `osv-scanner`).
+
+### Observabilidad
+- [ ] Endpoint `/health` (liveness/readiness) opt-in.
+- [ ] Métricas: contador/latencia por ruta con SPI `MetricsCollector`; adapter Micrometer (`ligero-metrics-micrometer`).
+- [ ] Access log estructurado (JSON) opcional.
+- [ ] Propagación de contexto de trazas (W3C `traceparent`) en el request-id middleware.
+
+### Motor
+- [ ] Segundo `ServerEngine` (Jetty o Helidon Nima) como prueba de fuego del SPI — valida DIP y habilita HTTP/2 y WebSockets.
+- [ ] WebSockets + SSE (sobre el engine que los soporte; API en `core`, implementación en el adapter).
+
+**Criterio de salida:** app de referencia desplegada con métricas, health checks y auth; sin hallazgos críticos en un análisis de seguridad básico.
+
+---
+
+## Fase 4 — Ecosistema y camino a 1.0 (v0.6 → v0.9 → v1.0.0)
+
+**Objetivo:** experiencia de desarrollador, comunidad y congelación de API.
+**Esfuerzo estimado:** continuo · **Prioridad:** media
+
+### Developer experience
+- [ ] `ligero-test`: `LigeroTest.create(app).get("/users/1").execute()` — servidor en puerto efímero + asserts fluidos.
+- [ ] OpenAPI: generación desde rutas registradas + UI swagger opt-in (`ligero-openapi`).
+- [ ] CLI de scaffolding (`ligero new`, `ligero generate`) — repositorio separado.
+- [ ] Hot-reload en modo dev (vía agente o integración con `gradle -t`).
+- [ ] Arquetipos/templates de proyecto (Gradle y Maven).
+
+### Calidad y rendimiento
+- [ ] Suite JMH permanente (routing, throughput end-to-end) con seguimiento de regresiones en CI.
+- [ ] Participar en TechEmpower benchmarks (visibilidad + validación de rendimiento).
+- [ ] Compatibilidad GraalVM native-image (sin reflexión en core la hace casi gratis) — arranque < 50 ms como argumento de marketing.
+- [ ] Verificación de compatibilidad binaria entre releases (`japicmp`) a partir de 0.9.
+
+### Gobernanza y release 1.0
+- [ ] Política semver estricta + `CHANGELOG.md` (Keep a Changelog) + notas de release automatizadas.
+- [ ] 0.9.x = **API freeze**: solo bugfixes y docs; RFC público para cambios de API.
+- [ ] Documentación completa en `docs/website` (Docusaurus ya existe): getting started, guías por feature, referencia, recetas, migración desde Spark/Javalin.
+- [ ] `CONTRIBUTING.md`, plantillas de issue/PR, código de conducta.
+- [ ] **1.0.0:** garantía de compatibilidad, política de soporte (última minor + una anterior), publicación estable en Maven Central.
+
+---
+
+## Explícitamente fuera de alcance (para proteger el "ligero")
+
+- ORM/persistencia propia (documentar integración con JDBC/jOOQ/JDBI en guías, no en código).
+- Contenedor DI con classpath scanning, proxies o AOP por bytecode.
+- Compatibilidad con Jakarta EE / servlets como API pública.
+- Programación reactiva (los virtual threads son la respuesta de Ligero a ese problema).
+
+## Resumen de secuencia
+
+| Fase | Versión | Tema | Duración est. |
+|------|---------|------|----------------|
+| 0 | 0.2.0 | Estabilización: bugs, deps, tests, CI | 2–3 semanas |
+| 1 | 0.3.0 | Middleware, SPIs, Context, trie router | 4–6 semanas |
+| 2 | 0.4.0 | Static, CORS, templates, config, validación | 4–6 semanas |
+| 3 | 0.5.0 | Seguridad, observabilidad, 2º engine, WS | 5–8 semanas |
+| 4 | 0.6–1.0 | DX, OpenAPI, benchmarks, API freeze | continuo |
+
+**Regla de oro:** ninguna feature nueva entra mientras haya bugs abiertos de la fase anterior en esa área.

--- a/ROUTE.md
+++ b/ROUTE.md
@@ -1,3 +1,5 @@
+> **⚠️ Documento histórico.** Estas notas iniciales fueron consolidadas en la hoja de ruta oficial: ver [ROADMAP.md](ROADMAP.md) y [ARCHITECTURE_ANALYSIS.md](ARCHITECTURE_ANALYSIS.md).
+
 ¡Fascinante! Crear tu propio framework con Java 21 y aprovechar las características de Project Loom (hilos virtuales y concurrencia estructurada) es un proyecto ambicioso y muy interesante. Te permitirá tener un control granular y optimizar el rendimiento de una manera que antes era mucho más compleja.
 
 Aquí te listo las cosas clave que deberías tener en cuenta:

--- a/TO_REVIEW.md
+++ b/TO_REVIEW.md
@@ -1,3 +1,5 @@
+> **⚠️ Documento histórico.** Estas notas iniciales fueron consolidadas en la hoja de ruta oficial: ver [ROADMAP.md](ROADMAP.md) y [ARCHITECTURE_ANALYSIS.md](ARCHITECTURE_ANALYSIS.md).
+
 Aquí tienes un resumen de las **ventajas y desventajas de Spring Boot** en formato Markdown:
 
 ---


### PR DESCRIPTION
## Resumen

Análisis técnico completo del framework y hoja de ruta canónica hacia la versión 1.0, consolidando las notas previas (`ROUTE.md`, `FRAMEWORK_IMPROVEMENTS.md`).

- **`ARCHITECTURE_ANALYSIS.md`**: diagnóstico con 14 bugs/defectos localizados (`archivo:línea`), evaluación SOLID principio por principio, análisis de escalabilidad, arquitectura objetivo y comparativa de mercado.
- **`ROADMAP.md`**: hoja de ruta en 5 fases (0.2 → 1.0) con tareas, criterios de aceptación y estimaciones, más reglas de arquitectura transversales.
- `README.md`: la sección de roadmap enlaza a los documentos nuevos.
- Notas históricas marcadas como sustituidas.

## Hallazgos principales

1. Los path params `{id}` no funcionan a través del servidor real (feature anunciada en el README).
2. `--enable-preview` global hace los artefactos inutilizables para consumidores.
3. El router depende de Javalin completo (con Jetty) sin usarlo.
4. Pool de hilos fijo en lugar de virtual threads (la premisa declarada del proyecto).
5. Sin tests, sin CI, módulo `core` vacío con la API viviendo en `server`.

> La ejecución de esta hoja de ruta está en el PR de implementación (rama `claude/roadmap-implementation-bhlhj6`), que incluye estos documentos; si se mergea aquel primero, este PR queda cubierto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5iQfCZ8PrTebn22UfjgVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5iQfCZ8PrTebn22UfjgVU)_