### PR TITLE
Feat: ligero-devtools — debugger visual (grafo de beans + trazas de requests en vivo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] — 0.2.0-SNAPSHOT
 
+### Added (devtools)
+- **`ligero-devtools`**: visual debugger for development served at
+  `/ligero/dev` — bean dependency graph colored by stereotype plus live
+  per-request traces through the layers (controller -> service ->
+  repository) with arguments, return values and timing per call, streamed
+  over SSE. Interface-typed beans are spied with JDK proxies through the
+  `BeanDecorator` hook; production carries zero overhead because the module
+  simply isn't on the classpath (`LIGERO_DEVTOOLS=false` also disables it).
+- `Beans.graph()` now tags nodes with the stereotype of the implementation
+  class when the binding key is an unannotated interface.
+
 ### Added (dependency container)
 - **`Beans` container** in core: explicit lambda bindings (compiler-verified,
   zero reflection), lazy memoized singletons, eager `start()` that validates

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ subprojects {
     def coverageMinimums = [core: 0.80, json: 0.70, server: 0.70, auth: 0.70,
                             'template-mustache': 0.60, 'template-freemarker': 0.60, 'template-pebble': 0.60, otel: 0.60, testkit: 0.60, openapi: 0.60,
                             'metrics-micrometer': 0.60, 'server-jetty': 0.50,
+                            devtools: 0.60,
                             examples: 0.0, benchmarks: 0.0]
     jacocoTestCoverageVerification {
         dependsOn test

--- a/core/src/main/java/com/ligero/beans/Beans.java
+++ b/core/src/main/java/com/ligero/beans/Beans.java
@@ -107,9 +107,25 @@ public final class Beans implements AutoCloseable {
     /** Typed dependency graph (nodes tagged by stereotype, edges from real resolution). */
     public BeanGraph graph() {
         List<BeanGraph.Node> nodes = factories.keySet().stream()
-            .map(type -> new BeanGraph.Node(type.getName(), stereotypeOf(type)))
+            .map(type -> new BeanGraph.Node(type.getName(), stereotypeFor(type)))
             .toList();
         return new BeanGraph(nodes, List.copyOf(edges));
+    }
+
+    /**
+     * Stereotype annotations usually live on the implementation class, not on
+     * the interface the bean is bound as — prefer the instantiated class when
+     * it carries one (decorator proxies don't, hence the fallback).
+     */
+    private String stereotypeFor(Class<?> bindingType) {
+        Object instance = singletons.get(bindingType);
+        if (instance != null) {
+            String stereotype = stereotypeOf(instance.getClass());
+            if (!"bean".equals(stereotype)) {
+                return stereotype;
+            }
+        }
+        return stereotypeOf(bindingType);
     }
 
     /** Closes instantiated {@link AutoCloseable} beans in reverse creation order. */

--- a/core/src/test/java/com/ligero/beans/BeansTest.java
+++ b/core/src/test/java/com/ligero/beans/BeansTest.java
@@ -128,11 +128,20 @@ class BeansTest {
         Beans beans = wired().start();
         BeanGraph graph = beans.graph();
 
+        // Repo is bound as an interface without annotation: the stereotype
+        // comes from the instantiated class (@Repository InMemoryRepo).
         assertThat(graph.nodes()).extracting(BeanGraph.Node::stereotype)
-            .containsExactlyInAnyOrder("bean", "service", "controller"); // Repo interface has no annotation
+            .containsExactlyInAnyOrder("repository", "service", "controller");
         assertThat(graph.edges()).contains(
             new BeanGraph.Edge(GreetingService.class.getName(), Repo.class.getName()),
             new BeanGraph.Edge(GreetingController.class.getName(), GreetingService.class.getName()));
+    }
+
+    @Test
+    void graphBeforeInstantiationFallsBackToBindingTypeStereotype() {
+        Beans beans = wired().buildLazy();
+        assertThat(beans.graph().nodes()).extracting(BeanGraph.Node::stereotype)
+            .containsExactlyInAnyOrder("bean", "service", "controller");
     }
 
     @Test

--- a/devtools/build.gradle
+++ b/devtools/build.gradle
@@ -1,0 +1,13 @@
+description = 'Ligero devtools: development dashboard (bean graph + per-request layer traces)'
+
+dependencies {
+    api project(':core')
+
+    testImplementation project(':server')
+    testImplementation project(':testkit')
+    testImplementation(testFixtures(project(':core')))
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly libs.junit.launcher
+    testImplementation libs.assertj.core
+    testRuntimeOnly libs.slf4j.simple
+}

--- a/devtools/src/main/java/com/ligero/devtools/Devtools.java
+++ b/devtools/src/main/java/com/ligero/devtools/Devtools.java
@@ -1,0 +1,130 @@
+package com.ligero.devtools;
+
+import com.ligero.Ligero;
+import com.ligero.beans.BeanDecorator;
+import com.ligero.beans.Beans;
+import com.ligero.http.SseEmitter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Development dashboard for Ligero: a visual debugger served at
+ * {@code /ligero/dev} showing the bean dependency graph (colored by
+ * stereotype) and a live trace of every request through the layers —
+ * controller, service, repository — with arguments, return values and
+ * timings per call.
+ *
+ * <pre>{@code
+ * Devtools devtools = Devtools.create();
+ *
+ * Beans beans = Beans.builder()
+ *     .bind(ProductRepository.class, b -> new JdbcProductRepository(b.get(DataSource.class)))
+ *     .bind(ProductService.class,    b -> new ProductService(b.get(ProductRepository.class)))
+ *     .instrument(devtools.recorder())   // spies interface-typed beans
+ *     .start();
+ *
+ * Ligero app = Ligero.create();
+ * app.beans(beans);
+ * devtools.install(app, beans);          // mounts /ligero/dev before app.start()
+ * }</pre>
+ *
+ * <p><strong>Development profile only.</strong> The dashboard exposes
+ * arguments and return values of your beans; never install it in
+ * production. Setting the environment variable {@code LIGERO_DEVTOOLS=false}
+ * turns {@link #install(Ligero, Beans)} into a no-op, so a deploy can switch
+ * it off without a code change.</p>
+ */
+public final class Devtools {
+
+    static final String BASE_PATH = "/ligero/dev";
+
+    private static final Logger log = LoggerFactory.getLogger(Devtools.class);
+    private static final int HISTORY = 100;
+    private static final long KEEP_ALIVE_SECONDS = 15;
+
+    private final TraceStore store = new TraceStore(HISTORY);
+    private final DevtoolsRecorder recorder = new DevtoolsRecorder();
+
+    private Devtools() {
+    }
+
+    public static Devtools create() {
+        return new Devtools();
+    }
+
+    /**
+     * The {@link BeanDecorator} to pass to {@code Beans.builder().instrument(...)}.
+     * Interface-typed beans get a spy proxy; concrete-class beans pass through
+     * untouched (and are listed on the dashboard as not traceable).
+     */
+    public BeanDecorator recorder() {
+        return recorder;
+    }
+
+    /**
+     * Mounts the dashboard and its API on the app. Call before
+     * {@code app.start()}.
+     */
+    public Devtools install(Ligero app, Beans beans) {
+        if ("false".equalsIgnoreCase(System.getenv("LIGERO_DEVTOOLS"))) {
+            log.info("LIGERO_DEVTOOLS=false — devtools disabled");
+            return this;
+        }
+        app.use(new TraceMiddleware(store));
+
+        app.get(BASE_PATH, ctx -> ctx.html(dashboardHtml()));
+
+        app.get(BASE_PATH + "/api/graph", ctx -> ctx.res()
+            .contentType("application/json; charset=utf-8")
+            .send(Json.graph(beans.graph(), recorder.stereotypes(), recorder.unspied())));
+
+        app.get(BASE_PATH + "/api/requests", ctx -> ctx.res()
+            .contentType("application/json; charset=utf-8")
+            .send(Json.traces(store.recent())));
+
+        app.get(BASE_PATH + "/api/stream", ctx -> {
+            SseEmitter sse = ctx.sse();
+            BlockingQueue<RequestTrace> queue = new LinkedBlockingQueue<>();
+            Consumer<RequestTrace> subscriber = queue::add;
+            store.subscribe(subscriber);
+            try {
+                while (true) {
+                    RequestTrace trace = queue.poll(KEEP_ALIVE_SECONDS, TimeUnit.SECONDS);
+                    if (trace == null) {
+                        sse.comment("keep-alive");
+                    } else {
+                        sse.send("trace", Json.trace(trace));
+                    }
+                }
+            } catch (UncheckedIOException clientGone) {
+                // browser tab closed — normal termination of the stream
+            } finally {
+                store.unsubscribe(subscriber);
+            }
+        });
+
+        log.info("Ligero devtools mounted at {} (development only)", BASE_PATH);
+        return this;
+    }
+
+    private static String dashboardHtml() {
+        try (InputStream in = Devtools.class.getResourceAsStream("dashboard.html")) {
+            if (in == null) {
+                throw new IllegalStateException("dashboard.html missing from ligero-devtools jar");
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/devtools/src/main/java/com/ligero/devtools/DevtoolsRecorder.java
+++ b/devtools/src/main/java/com/ligero/devtools/DevtoolsRecorder.java
@@ -1,0 +1,131 @@
+package com.ligero.devtools;
+
+import com.ligero.beans.BeanDecorator;
+import com.ligero.beans.stereotype.Component;
+import com.ligero.beans.stereotype.Controller;
+import com.ligero.beans.stereotype.Repository;
+import com.ligero.beans.stereotype.Service;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * {@link BeanDecorator} that wraps interface-typed beans in a
+ * {@link Proxy JDK dynamic proxy} recording every call — method, arguments,
+ * return value preview and elapsed time — into the {@link RequestTrace} of
+ * the request being handled (if any; outside a request the proxy is a
+ * pass-through).
+ *
+ * <p>Beans bound as concrete classes cannot be proxied without bytecode
+ * generation, so they stay unwrapped; the dashboard lists them so it is
+ * obvious why their calls don't show up in traces.</p>
+ */
+final class DevtoolsRecorder implements BeanDecorator {
+
+    private static final int PREVIEW_MAX = 240;
+
+    /** Trace of the request currently handled by this thread (one request = one thread). */
+    static final ThreadLocal<RequestTrace> CURRENT = new ThreadLocal<>();
+
+    /** Binding type name -> stereotype of the real implementation class. */
+    private final Map<String, String> stereotypes = new ConcurrentHashMap<>();
+
+    /** Concrete-class bindings we could not spy (shown as a dashboard notice). */
+    private final List<String> unspied = new CopyOnWriteArrayList<>();
+
+    @Override
+    public <T> T decorate(Class<T> type, T bean) {
+        String stereotype = stereotypeOf(bean.getClass());
+        stereotypes.put(type.getName(), stereotype);
+        if (!type.isInterface()) {
+            unspied.add(type.getName());
+            return bean;
+        }
+        String beanName = bean.getClass().getSimpleName();
+        String declaredBy = type.getSimpleName();
+        Object proxy = Proxy.newProxyInstance(
+            type.getClassLoader(),
+            new Class<?>[] {type},
+            (p, method, args) -> spy(bean, beanName, declaredBy, stereotype, method, args));
+        return type.cast(proxy);
+    }
+
+    private Object spy(Object bean, String beanName, String declaredBy, String stereotype,
+                       Method method, Object[] args) throws Throwable {
+        RequestTrace trace = CURRENT.get();
+        if (trace == null || method.getDeclaringClass() == Object.class) {
+            return invoke(bean, method, args);
+        }
+        RequestTrace.Call call =
+            trace.enter(beanName, declaredBy, stereotype, method.getName(), preview(args));
+        long start = System.nanoTime();
+        try {
+            Object result = invoke(bean, method, args);
+            call.complete(preview(result), null, (System.nanoTime() - start) / 1_000);
+            return result;
+        } catch (Throwable e) {
+            call.complete(null, e.getClass().getSimpleName() + ": " + e.getMessage(),
+                          (System.nanoTime() - start) / 1_000);
+            throw e;
+        } finally {
+            trace.exit();
+        }
+    }
+
+    private static Object invoke(Object bean, Method method, Object[] args) throws Throwable {
+        try {
+            return method.invoke(bean, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    Map<String, String> stereotypes() {
+        return Map.copyOf(stereotypes);
+    }
+
+    List<String> unspied() {
+        return List.copyOf(unspied);
+    }
+
+    static String preview(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        String text;
+        if (value instanceof Object[] array) {
+            StringBuilder sb = new StringBuilder();
+            for (Object item : array) {
+                if (sb.length() > 0) {
+                    sb.append(", ");
+                }
+                sb.append(item);
+            }
+            text = sb.toString();
+        } else {
+            text = String.valueOf(value);
+        }
+        return text.length() <= PREVIEW_MAX ? text : text.substring(0, PREVIEW_MAX) + "…";
+    }
+
+    private static String stereotypeOf(Class<?> type) {
+        if (type.isAnnotationPresent(Controller.class)) {
+            return "controller";
+        }
+        if (type.isAnnotationPresent(Service.class)) {
+            return "service";
+        }
+        if (type.isAnnotationPresent(Repository.class)) {
+            return "repository";
+        }
+        if (type.isAnnotationPresent(Component.class)) {
+            return "component";
+        }
+        return "bean";
+    }
+}

--- a/devtools/src/main/java/com/ligero/devtools/Json.java
+++ b/devtools/src/main/java/com/ligero/devtools/Json.java
@@ -1,0 +1,129 @@
+package com.ligero.devtools;
+
+import com.ligero.beans.BeanGraph;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Minimal hand-rolled JSON writer for the two devtools payloads (graph and
+ * traces). Keeps ligero-devtools free of any JSON library so it only depends
+ * on ligero-core.
+ */
+final class Json {
+
+    private Json() {
+    }
+
+    static String graph(BeanGraph graph, Map<String, String> stereotypeOverlay,
+                        List<String> unspied) {
+        StringBuilder sb = new StringBuilder(1024);
+        sb.append("{\"nodes\":[");
+        boolean first = true;
+        for (BeanGraph.Node node : graph.nodes()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            // The graph tags nodes by binding type; when the annotation lives on
+            // the implementation class, the recorder saw it at decoration time.
+            String stereotype = node.stereotype();
+            if ("bean".equals(stereotype)) {
+                stereotype = stereotypeOverlay.getOrDefault(node.type(), stereotype);
+            }
+            sb.append("{\"type\":").append(str(node.type()))
+              .append(",\"stereotype\":").append(str(stereotype)).append('}');
+        }
+        sb.append("],\"edges\":[");
+        first = true;
+        for (BeanGraph.Edge edge : graph.edges()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append("{\"from\":").append(str(edge.from()))
+              .append(",\"to\":").append(str(edge.to())).append('}');
+        }
+        sb.append("],\"unspied\":[");
+        first = true;
+        for (String type : unspied) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append(str(type));
+        }
+        return sb.append("]}").toString();
+    }
+
+    static String traces(List<RequestTrace> traces) {
+        StringBuilder sb = new StringBuilder(2048).append('[');
+        for (int i = 0; i < traces.size(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            trace(sb, traces.get(i));
+        }
+        return sb.append(']').toString();
+    }
+
+    static String trace(RequestTrace trace) {
+        StringBuilder sb = new StringBuilder(512);
+        trace(sb, trace);
+        return sb.toString();
+    }
+
+    private static void trace(StringBuilder sb, RequestTrace t) {
+        sb.append("{\"id\":").append(str(t.id()))
+          .append(",\"method\":").append(str(t.method()))
+          .append(",\"path\":").append(str(t.path()))
+          .append(",\"status\":").append(t.status())
+          .append(",\"startedAt\":").append(t.startedAtMs())
+          .append(",\"durationUs\":").append(t.durationUs())
+          .append(",\"calls\":[");
+        List<RequestTrace.Call> calls = t.calls();
+        for (int i = 0; i < calls.size(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            RequestTrace.Call c = calls.get(i);
+            sb.append("{\"order\":").append(c.order())
+              .append(",\"depth\":").append(c.depth())
+              .append(",\"bean\":").append(str(c.bean()))
+              .append(",\"declaredBy\":").append(str(c.declaredBy()))
+              .append(",\"stereotype\":").append(str(c.stereotype()))
+              .append(",\"method\":").append(str(c.method()))
+              .append(",\"args\":").append(str(c.args()))
+              .append(",\"result\":").append(str(c.result()))
+              .append(",\"error\":").append(str(c.error()))
+              .append(",\"durationUs\":").append(c.durationUs())
+              .append('}');
+        }
+        sb.append("]}");
+    }
+
+    static String str(String value) {
+        if (value == null) {
+            return "null";
+        }
+        StringBuilder sb = new StringBuilder(value.length() + 2).append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.append('"').toString();
+    }
+}

--- a/devtools/src/main/java/com/ligero/devtools/RequestTrace.java
+++ b/devtools/src/main/java/com/ligero/devtools/RequestTrace.java
@@ -1,0 +1,106 @@
+package com.ligero.devtools;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * One request as seen by devtools: method, path, status, elapsed time and
+ * the ordered list of spied bean calls made while handling it.
+ *
+ * <p>A request is handled by a single (virtual) thread, so {@link Call}s are
+ * appended without contention; volatile fields make the completed trace safe
+ * to read from the dashboard's SSE thread.</p>
+ */
+public final class RequestTrace {
+
+    /** One spied call: {@code bean.method(args) -> result} with depth for the tree view. */
+    public static final class Call {
+        private final int order;
+        private final int depth;
+        private final String bean;       // implementation class (simple name)
+        private final String declaredBy; // interface the bean was bound as
+        private final String stereotype;
+        private final String method;
+        private final String args;
+        private volatile String result;
+        private volatile String error;
+        private volatile long durationUs;
+
+        Call(int order, int depth, String bean, String declaredBy, String stereotype,
+             String method, String args) {
+            this.order = order;
+            this.depth = depth;
+            this.bean = bean;
+            this.declaredBy = declaredBy;
+            this.stereotype = stereotype;
+            this.method = method;
+            this.args = args;
+        }
+
+        void complete(String result, String error, long durationUs) {
+            this.result = result;
+            this.error = error;
+            this.durationUs = durationUs;
+        }
+
+        public int order() { return order; }
+        public int depth() { return depth; }
+        public String bean() { return bean; }
+        public String declaredBy() { return declaredBy; }
+        public String stereotype() { return stereotype; }
+        public String method() { return method; }
+        public String args() { return args; }
+        public String result() { return result; }
+        public String error() { return error; }
+        public long durationUs() { return durationUs; }
+    }
+
+    private final String id;
+    private final String method;
+    private final String path;
+    private final long startedAtMs;
+    private final long startNanos;
+    private final List<Call> calls = Collections.synchronizedList(new ArrayList<>());
+    private volatile int status;
+    private volatile long durationUs;
+    private int depth;
+    private int nextOrder;
+
+    RequestTrace(String id, String method, String path) {
+        this.id = id;
+        this.method = method;
+        this.path = path;
+        this.startedAtMs = System.currentTimeMillis();
+        this.startNanos = System.nanoTime();
+    }
+
+    Call enter(String bean, String declaredBy, String stereotype, String method, String args) {
+        Call call = new Call(nextOrder++, depth++, bean, declaredBy, stereotype, method, args);
+        calls.add(call);
+        return call;
+    }
+
+    void exit() {
+        depth--;
+    }
+
+    void finish(int status) {
+        this.status = status;
+        this.durationUs = (System.nanoTime() - startNanos) / 1_000;
+    }
+
+    public String id() { return id; }
+    public String method() { return method; }
+    public String path() { return path; }
+    public long startedAtMs() { return startedAtMs; }
+    public int status() { return status; }
+    public long durationUs() { return durationUs; }
+
+    /** Snapshot of the recorded calls, in entry order. */
+    public List<Call> calls() {
+        synchronized (calls) {
+            return List.copyOf(calls);
+        }
+    }
+}

--- a/devtools/src/main/java/com/ligero/devtools/TraceMiddleware.java
+++ b/devtools/src/main/java/com/ligero/devtools/TraceMiddleware.java
@@ -1,0 +1,49 @@
+package com.ligero.devtools;
+
+import com.ligero.http.Context;
+import com.ligero.http.HttpException;
+import com.ligero.middleware.Middleware;
+
+import java.util.UUID;
+
+/**
+ * Opens a {@link RequestTrace} for every request (except the devtools
+ * endpoints themselves), makes it visible to the spy proxies through
+ * {@link DevtoolsRecorder#CURRENT} and publishes the completed trace to the
+ * {@link TraceStore} when the pipeline finishes.
+ */
+final class TraceMiddleware implements Middleware {
+
+    private final TraceStore store;
+
+    TraceMiddleware(TraceStore store) {
+        this.store = store;
+    }
+
+    @Override
+    public void handle(Context ctx, Chain chain) throws Exception {
+        if (ctx.path().startsWith(Devtools.BASE_PATH)) {
+            chain.proceed();
+            return;
+        }
+        String requestId = ctx.attribute("requestId");
+        if (requestId == null) {
+            requestId = UUID.randomUUID().toString().substring(0, 8);
+        }
+        RequestTrace trace = new RequestTrace(requestId, ctx.method(), ctx.path());
+        DevtoolsRecorder.CURRENT.set(trace);
+        int errorStatus = 0;
+        try {
+            chain.proceed();
+        } catch (Exception e) {
+            // Exception mapping happens outside this middleware, so read the
+            // final status from the exception itself before rethrowing.
+            errorStatus = e instanceof HttpException http ? http.getStatus() : 500;
+            throw e;
+        } finally {
+            DevtoolsRecorder.CURRENT.remove();
+            trace.finish(errorStatus != 0 ? errorStatus : ctx.res().getStatus());
+            store.add(trace);
+        }
+    }
+}

--- a/devtools/src/main/java/com/ligero/devtools/TraceStore.java
+++ b/devtools/src/main/java/com/ligero/devtools/TraceStore.java
@@ -1,0 +1,53 @@
+package com.ligero.devtools;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+/**
+ * Bounded in-memory history of completed {@link RequestTrace}s plus a
+ * subscriber list for the dashboard's live SSE stream.
+ */
+final class TraceStore {
+
+    private final int capacity;
+    private final Deque<RequestTrace> traces = new ArrayDeque<>();
+    private final List<Consumer<RequestTrace>> subscribers = new CopyOnWriteArrayList<>();
+
+    TraceStore(int capacity) {
+        this.capacity = capacity;
+    }
+
+    void add(RequestTrace trace) {
+        synchronized (traces) {
+            if (traces.size() == capacity) {
+                traces.removeLast();
+            }
+            traces.addFirst(trace);
+        }
+        for (Consumer<RequestTrace> subscriber : subscribers) {
+            try {
+                subscriber.accept(trace);
+            } catch (RuntimeException ignored) {
+                // a broken subscriber must not affect request handling
+            }
+        }
+    }
+
+    /** Most recent first. */
+    List<RequestTrace> recent() {
+        synchronized (traces) {
+            return List.copyOf(traces);
+        }
+    }
+
+    void subscribe(Consumer<RequestTrace> subscriber) {
+        subscribers.add(subscriber);
+    }
+
+    void unsubscribe(Consumer<RequestTrace> subscriber) {
+        subscribers.remove(subscriber);
+    }
+}

--- a/devtools/src/main/java/module-info.java
+++ b/devtools/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+/**
+ * Ligero devtools: development-time dashboard served at {@code /ligero/dev}
+ * with the bean dependency graph and live per-request traces through the
+ * layers (controller -&gt; service -&gt; repository). Development profile only —
+ * never put this module on a production classpath.
+ */
+module com.ligero.devtools {
+    requires transitive com.ligero.core;
+
+    exports com.ligero.devtools;
+}

--- a/devtools/src/main/resources/com/ligero/devtools/dashboard.html
+++ b/devtools/src/main/resources/com/ligero/devtools/dashboard.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ligero Devtools</title>
+<style>
+  :root {
+    --bg: #0f1117; --panel: #171a23; --border: #262b3a; --text: #d6dae5;
+    --muted: #7c86a0; --accent: #7ee0a3;
+    --controller: #5aa9f7; --service: #7ee0a3; --repository: #f7b955;
+    --component: #c792ea; --bean: #8a93ab; --error: #ef6b73;
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body { background: var(--bg); color: var(--text); font: 14px/1.5 ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+  header { display: flex; align-items: baseline; gap: 18px; padding: 14px 22px; border-bottom: 1px solid var(--border); }
+  header h1 { font-size: 17px; letter-spacing: .4px; }
+  header h1 span { color: var(--accent); }
+  header .sub { color: var(--muted); font-size: 12px; }
+  nav { display: flex; gap: 4px; padding: 10px 22px 0; }
+  nav button { background: none; border: 1px solid transparent; border-bottom: none; color: var(--muted);
+    font: inherit; padding: 7px 16px; cursor: pointer; border-radius: 8px 8px 0 0; }
+  nav button.active { color: var(--text); background: var(--panel); border-color: var(--border); }
+  main { padding: 16px 22px; }
+  .tab { display: none; }
+  .tab.active { display: block; }
+  .legend { display: flex; gap: 16px; margin-bottom: 12px; color: var(--muted); font-size: 12px; flex-wrap: wrap; }
+  .legend i { display: inline-block; width: 10px; height: 10px; border-radius: 3px; margin-right: 5px; }
+  .notice { background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+    padding: 8px 12px; color: var(--muted); font-size: 12px; margin-bottom: 12px; }
+  #graph-box { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; overflow: auto; }
+  svg text { fill: var(--text); font: 12px ui-monospace, Menlo, Consolas, monospace; }
+  svg .edge { stroke: #3a4157; stroke-width: 1.4; fill: none; marker-end: url(#arrow); }
+  svg .node rect { rx: 7; fill: #1e2330; stroke-width: 1.6; }
+  table { width: 100%; border-collapse: collapse; }
+  th { text-align: left; color: var(--muted); font-weight: normal; font-size: 12px;
+    padding: 6px 10px; border-bottom: 1px solid var(--border); }
+  td { padding: 7px 10px; border-bottom: 1px solid var(--border); }
+  tr.req { cursor: pointer; }
+  tr.req:hover td { background: #1b2029; }
+  .m { color: var(--accent); }
+  .status-2 { color: var(--accent); } .status-3 { color: var(--controller); }
+  .status-4 { color: var(--repository); } .status-5 { color: var(--error); }
+  .dur { color: var(--muted); }
+  tr.detail td { background: #12151d; padding: 10px 14px 12px; }
+  .call { padding: 2px 0; white-space: pre-wrap; word-break: break-word; }
+  .call .stereo { display: inline-block; min-width: 86px; font-size: 11px; }
+  .call .ret { color: var(--muted); }
+  .call .err { color: var(--error); }
+  .empty { color: var(--muted); padding: 30px 0; text-align: center; }
+  #live { color: var(--muted); font-size: 12px; margin-left: auto; }
+  #live.on::before { content: "●"; color: var(--accent); margin-right: 6px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ligero <span>devtools</span></h1>
+  <span class="sub">visual debugger — development profile only</span>
+  <span id="live"></span>
+</header>
+<nav>
+  <button id="tab-beans" class="active" onclick="show('beans')">Beans</button>
+  <button id="tab-requests" onclick="show('requests')">Requests</button>
+</nav>
+<main>
+  <section id="beans" class="tab active">
+    <div class="legend">
+      <span><i style="background:var(--controller)"></i>controller</span>
+      <span><i style="background:var(--service)"></i>service</span>
+      <span><i style="background:var(--repository)"></i>repository</span>
+      <span><i style="background:var(--component)"></i>component</span>
+      <span><i style="background:var(--bean)"></i>bean</span>
+    </div>
+    <div id="unspied" class="notice" style="display:none"></div>
+    <div id="graph-box"></div>
+  </section>
+  <section id="requests" class="tab">
+    <table>
+      <thead><tr><th style="width:70px">method</th><th>path</th><th style="width:70px">status</th>
+        <th style="width:100px">duration</th><th style="width:70px">calls</th></tr></thead>
+      <tbody id="rows"></tbody>
+    </table>
+    <div id="no-requests" class="empty">no requests traced yet — hit an endpoint of your app</div>
+  </section>
+</main>
+<script>
+const COLORS = { controller:'var(--controller)', service:'var(--service)',
+  repository:'var(--repository)', component:'var(--component)', bean:'var(--bean)' };
+const base = location.pathname.replace(/\/$/, '');
+
+function show(tab) {
+  for (const t of ['beans','requests']) {
+    document.getElementById(t).classList.toggle('active', t === tab);
+    document.getElementById('tab-' + t).classList.toggle('active', t === tab);
+  }
+}
+const simple = fqn => fqn.substring(fqn.lastIndexOf('.') + 1);
+const fmtUs = us => us >= 1000 ? (us / 1000).toFixed(1) + ' ms' : us + ' µs';
+
+/* ---- Beans graph: layered left-to-right (consumers -> dependencies) ---- */
+async function drawGraph() {
+  const g = await (await fetch(base + '/api/graph')).json();
+  if (g.unspied.length) {
+    const div = document.getElementById('unspied');
+    div.style.display = 'block';
+    div.textContent = 'not traceable (bound as concrete classes, bind them as interfaces to spy their calls): '
+      + g.unspied.map(simple).join(', ');
+  }
+  const deps = {};                       // type -> [dependencies]
+  g.nodes.forEach(n => deps[n.type] = []);
+  g.edges.forEach(e => { if (deps[e.from]) deps[e.from].push(e.to); });
+  const level = {};                      // longest path to a leaf dependency
+  const depth = t => {
+    if (t in level) return level[t];
+    level[t] = 0;                        // breaks cycles defensively
+    level[t] = deps[t].length ? 1 + Math.max(...deps[t].map(depth)) : 0;
+    return level[t];
+  };
+  g.nodes.forEach(n => depth(n.type));
+  const maxLevel = Math.max(0, ...Object.values(level));
+  const cols = [];                       // column 0 = consumers (highest level)
+  g.nodes.forEach(n => {
+    const col = maxLevel - level[n.type];
+    (cols[col] = cols[col] || []).push(n);
+  });
+  const BW = 190, BH = 34, GX = 90, GY = 22, PAD = 30;
+  const pos = {};
+  cols.forEach((col, ci) => col.forEach((n, ri) => {
+    pos[n.type] = { x: PAD + ci * (BW + GX), y: PAD + ri * (BH + GY), n };
+  }));
+  const width = PAD * 2 + cols.length * BW + (cols.length - 1) * GX;
+  const height = PAD * 2 + Math.max(0, ...cols.map(c => c.length)) * (BH + GY) - GY;
+  let s = `<svg width="${Math.max(width, 400)}" height="${Math.max(height, 120)}">`
+    + '<defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+    + '<path d="M 0 0 L 10 5 L 0 10 z" fill="#3a4157"/></marker></defs>';
+  for (const e of g.edges) {
+    const a = pos[e.from], b = pos[e.to];
+    if (!a || !b) continue;
+    const x1 = a.x + BW, y1 = a.y + BH / 2, x2 = b.x, y2 = b.y + BH / 2;
+    const mx = (x1 + x2) / 2;
+    s += `<path class="edge" d="M ${x1} ${y1} C ${mx} ${y1}, ${mx} ${y2}, ${x2} ${y2}"/>`;
+  }
+  for (const t in pos) {
+    const { x, y, n } = pos[t];
+    const color = COLORS[n.stereotype] || COLORS.bean;
+    const name = simple(t);
+    s += `<g class="node"><title>${t} (${n.stereotype})</title>`
+      + `<rect x="${x}" y="${y}" width="${BW}" height="${BH}" stroke="${color}"/>`
+      + `<text x="${x + BW / 2}" y="${y + BH / 2 + 4}" text-anchor="middle">${name}</text></g>`;
+  }
+  document.getElementById('graph-box').innerHTML = s + '</svg>';
+}
+
+/* ---- Requests: history + live SSE ---- */
+const esc = t => (t ?? '').toString().replace(/&/g, '&amp;').replace(/</g, '&lt;');
+
+function addTrace(t, prepend) {
+  document.getElementById('no-requests').style.display = 'none';
+  const rows = document.getElementById('rows');
+  const tr = document.createElement('tr');
+  tr.className = 'req';
+  tr.innerHTML = `<td class="m">${esc(t.method)}</td><td>${esc(t.path)}</td>`
+    + `<td class="status-${Math.floor(t.status / 100)}">${t.status}</td>`
+    + `<td class="dur">${fmtUs(t.durationUs)}</td><td class="dur">${t.calls.length}</td>`;
+  const detail = document.createElement('tr');
+  detail.className = 'detail';
+  detail.style.display = 'none';
+  const calls = t.calls.length === 0
+    ? '<div class="call ret">no spied bean calls (are your beans bound as interfaces and instrumented?)</div>'
+    : t.calls.map(c => {
+        const color = COLORS[c.stereotype] || COLORS.bean;
+        const indent = '&nbsp;'.repeat(c.depth * 4);
+        const outcome = c.error
+          ? `<span class="err">✗ ${esc(c.error)}</span>`
+          : `<span class="ret">→ ${esc(c.result)}</span>`;
+        return `<div class="call">${indent}<span class="stereo" style="color:${color}">[${c.stereotype}]</span> `
+          + `<b>${esc(c.bean)}</b>.${esc(c.method)}(${esc(c.args)}) ${outcome} `
+          + `<span class="ret">· ${fmtUs(c.durationUs)}</span></div>`;
+      }).join('');
+  detail.innerHTML = `<td colspan="5"><div class="ret" style="color:var(--muted);margin-bottom:6px">`
+    + `request ${esc(t.id)} · ${new Date(t.startedAt).toLocaleTimeString()}</div>${calls}</td>`;
+  tr.onclick = () => detail.style.display = detail.style.display === 'none' ? '' : 'none';
+  if (prepend && rows.firstChild) {
+    rows.insertBefore(detail, rows.firstChild);
+    rows.insertBefore(tr, detail);
+  } else {
+    rows.appendChild(tr);
+    rows.appendChild(detail);
+  }
+}
+
+async function loadRequests() {
+  const traces = await (await fetch(base + '/api/requests')).json();
+  traces.forEach(t => addTrace(t, false));
+}
+
+function connect() {
+  const es = new EventSource(base + '/api/stream');
+  const live = document.getElementById('live');
+  es.onopen = () => { live.classList.add('on'); live.textContent = 'live'; };
+  es.onerror = () => { live.classList.remove('on'); live.textContent = 'reconnecting…'; };
+  es.addEventListener('trace', ev => addTrace(JSON.parse(ev.data), true));
+}
+
+drawGraph();
+loadRequests().then(connect);
+</script>
+</body>
+</html>

--- a/devtools/src/test/java/com/ligero/devtools/DevtoolsE2ETest.java
+++ b/devtools/src/test/java/com/ligero/devtools/DevtoolsE2ETest.java
@@ -1,0 +1,167 @@
+package com.ligero.devtools;
+
+import com.ligero.Ligero;
+import com.ligero.beans.Beans;
+import com.ligero.beans.stereotype.Repository;
+import com.ligero.beans.stereotype.Service;
+import com.ligero.test.LigeroTest;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Boots a small layered app (route -> GreetService -> NameRepo, both bound
+ * as interfaces) with devtools installed and checks the dashboard, the graph
+ * API, the trace API and the live SSE stream over real HTTP.
+ */
+class DevtoolsE2ETest {
+
+    interface NameRepo {
+        String find(int id);
+    }
+
+    interface GreetService {
+        String greet(int id);
+    }
+
+    @Repository
+    static class FixedNameRepo implements NameRepo {
+        @Override
+        public String find(int id) {
+            return "user-" + id;
+        }
+    }
+
+    @Service
+    static class DefaultGreetService implements GreetService {
+        private final NameRepo repo;
+
+        DefaultGreetService(NameRepo repo) {
+            this.repo = repo;
+        }
+
+        @Override
+        public String greet(int id) {
+            return "hello " + repo.find(id);
+        }
+    }
+
+    private static LigeroTest server;
+
+    @BeforeAll
+    static void start() {
+        server = LigeroTest.create(app -> {
+            Devtools devtools = Devtools.create();
+            Beans beans = Beans.builder()
+                .bind(NameRepo.class, b -> new FixedNameRepo())
+                .bind(GreetService.class, b -> new DefaultGreetService(b.get(NameRepo.class)))
+                .instrument(devtools.recorder())
+                .start();
+            app.beans(beans);
+            devtools.install(app, beans);
+            app.get("/greet/{id}", ctx ->
+                ctx.text(ctx.get(GreetService.class).greet(ctx.pathParamAsInt("id"))));
+        });
+    }
+
+    @AfterAll
+    static void stop() {
+        server.close();
+    }
+
+    @Test
+    void servesTheDashboard() {
+        LigeroTest.TestResponse response = server.get("/ligero/dev").execute();
+        assertThat(response.status()).isEqualTo(200);
+        assertThat(response.header("Content-Type")).contains("text/html");
+        assertThat(response.body()).contains("Ligero Devtools").contains("api/stream");
+    }
+
+    @Test
+    void graphApiExposesNodesEdgesAndImplementationStereotypes() {
+        LigeroTest.TestResponse response = server.get("/ligero/dev/api/graph").execute();
+        assertThat(response.status()).isEqualTo(200);
+        assertThat(response.header("Content-Type")).contains("application/json");
+        assertThat(response.body())
+            .contains("\"type\":\"" + NameRepo.class.getName() + "\",\"stereotype\":\"repository\"")
+            .contains("\"type\":\"" + GreetService.class.getName() + "\",\"stereotype\":\"service\"")
+            .contains("\"from\":\"" + GreetService.class.getName() + "\",\"to\":\"" + NameRepo.class.getName() + "\"");
+    }
+
+    @Test
+    void tracesARequestThroughServiceAndRepositoryLayers() {
+        LigeroTest.TestResponse greeting = server.get("/greet/7").execute();
+        assertThat(greeting.body()).isEqualTo("hello user-7");
+
+        String traces = server.get("/ligero/dev/api/requests").execute().body();
+        assertThat(traces)
+            .contains("\"path\":\"/greet/7\"")
+            .contains("\"status\":200")
+            // service call at depth 0, repository call nested at depth 1
+            .contains("\"depth\":0,\"bean\":\"DefaultGreetService\",\"declaredBy\":\"GreetService\","
+                      + "\"stereotype\":\"service\",\"method\":\"greet\",\"args\":\"7\"")
+            .contains("\"depth\":1,\"bean\":\"FixedNameRepo\",\"declaredBy\":\"NameRepo\","
+                      + "\"stereotype\":\"repository\",\"method\":\"find\",\"args\":\"7\"")
+            .contains("\"result\":\"hello user-7\"")
+            .contains("\"result\":\"user-7\"");
+    }
+
+    @Test
+    void devtoolsEndpointsAreNotTracedThemselves() {
+        server.get("/ligero/dev/api/graph").execute();
+        String traces = server.get("/ligero/dev/api/requests").execute().body();
+        assertThat(traces).doesNotContain("\"path\":\"/ligero/dev");
+    }
+
+    @Test
+    void streamPushesCompletedTracesLive() throws Exception {
+        CompletableFuture<String> firstEvent = new CompletableFuture<>();
+        Thread reader = Thread.ofVirtual().start(() -> {
+            try {
+                HttpURLConnection connection = (HttpURLConnection) URI
+                    .create(server.baseUrl() + "/ligero/dev/api/stream").toURL().openConnection();
+                connection.setReadTimeout(10_000);
+                try (BufferedReader in = new BufferedReader(
+                        new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = in.readLine()) != null) {
+                        if (line.startsWith("data: ") && line.contains("\"path\":\"/greet/9\"")) {
+                            firstEvent.complete(line.substring("data: ".length()));
+                            return;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                firstEvent.completeExceptionally(e);
+            }
+        });
+
+        // The SSE handler subscribes right after committing headers; retry the
+        // traced request until the event lands (bounded by the future timeout).
+        String data = null;
+        for (int attempt = 0; attempt < 25 && data == null; attempt++) {
+            server.get("/greet/9").execute();
+            try {
+                data = firstEvent.get(400, TimeUnit.MILLISECONDS);
+            } catch (java.util.concurrent.TimeoutException retry) {
+                // not yet — fire again
+            }
+        }
+        assertThat(data)
+            .isNotNull()
+            .contains("\"path\":\"/greet/9\"")
+            .contains("\"bean\":\"FixedNameRepo\"");
+        reader.interrupt();
+    }
+}

--- a/devtools/src/test/java/com/ligero/devtools/DevtoolsRecorderTest.java
+++ b/devtools/src/test/java/com/ligero/devtools/DevtoolsRecorderTest.java
@@ -1,0 +1,115 @@
+package com.ligero.devtools;
+
+import com.ligero.beans.Beans;
+import com.ligero.beans.stereotype.Repository;
+import com.ligero.beans.stereotype.Service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DevtoolsRecorderTest {
+
+    interface Repo {
+        String find(int id);
+    }
+
+    @Repository
+    static class StubRepo implements Repo {
+        @Override
+        public String find(int id) {
+            if (id < 0) {
+                throw new IllegalArgumentException("negative id");
+            }
+            return "item-" + id;
+        }
+    }
+
+    @Service
+    static class PlainService {
+    }
+
+    @AfterEach
+    void clearTrace() {
+        DevtoolsRecorder.CURRENT.remove();
+    }
+
+    @Test
+    void spiesInterfaceBeansIntoTheCurrentTrace() {
+        DevtoolsRecorder recorder = new DevtoolsRecorder();
+        Beans beans = Beans.builder()
+            .bind(Repo.class, b -> new StubRepo())
+            .instrument(recorder)
+            .start();
+
+        RequestTrace trace = new RequestTrace("t1", "GET", "/items/7");
+        DevtoolsRecorder.CURRENT.set(trace);
+        String result = beans.get(Repo.class).find(7);
+        assertThat(result).isEqualTo("item-7");
+
+        List<RequestTrace.Call> calls = trace.calls();
+        assertThat(calls).hasSize(1);
+        RequestTrace.Call call = calls.get(0);
+        assertThat(call.bean()).isEqualTo("StubRepo");
+        assertThat(call.declaredBy()).isEqualTo("Repo");
+        assertThat(call.stereotype()).isEqualTo("repository");
+        assertThat(call.method()).isEqualTo("find");
+        assertThat(call.args()).isEqualTo("7");
+        assertThat(call.result()).isEqualTo("item-7");
+        assertThat(call.error()).isNull();
+    }
+
+    @Test
+    void recordsFailuresAndRethrowsTheOriginalException() {
+        DevtoolsRecorder recorder = new DevtoolsRecorder();
+        Beans beans = Beans.builder()
+            .bind(Repo.class, b -> new StubRepo())
+            .instrument(recorder)
+            .start();
+        Repo repo = beans.get(Repo.class);
+
+        RequestTrace trace = new RequestTrace("t2", "GET", "/items/-1");
+        DevtoolsRecorder.CURRENT.set(trace);
+        assertThatThrownBy(() -> repo.find(-1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("negative id");
+        assertThat(trace.calls().get(0).error())
+            .isEqualTo("IllegalArgumentException: negative id");
+    }
+
+    @Test
+    void outsideARequestTheProxyIsAPassThrough() {
+        DevtoolsRecorder recorder = new DevtoolsRecorder();
+        Beans beans = Beans.builder()
+            .bind(Repo.class, b -> new StubRepo())
+            .instrument(recorder)
+            .start();
+        assertThat(beans.get(Repo.class).find(1)).isEqualTo("item-1");
+        // no trace open, nothing recorded, nothing blows up
+    }
+
+    @Test
+    void concreteClassBeansAreLeftUnwrappedAndListed() {
+        DevtoolsRecorder recorder = new DevtoolsRecorder();
+        Beans beans = Beans.builder()
+            .bind(PlainService.class, b -> new PlainService())
+            .instrument(recorder)
+            .start();
+        assertThat(beans.get(PlainService.class)).isExactlyInstanceOf(PlainService.class);
+        assertThat(recorder.unspied()).containsExactly(PlainService.class.getName());
+        assertThat(recorder.stereotypes())
+            .containsEntry(PlainService.class.getName(), "service");
+    }
+
+    @Test
+    void previewTruncatesLongValuesAndJoinsArrays() {
+        assertThat(DevtoolsRecorder.preview(null)).isEqualTo("null");
+        assertThat(DevtoolsRecorder.preview(new Object[] {1, "a"})).isEqualTo("1, a");
+        String longText = "x".repeat(500);
+        assertThat(DevtoolsRecorder.preview(longText)).hasSize(241).endsWith("…");
+    }
+}

--- a/devtools/src/test/java/com/ligero/devtools/JsonTest.java
+++ b/devtools/src/test/java/com/ligero/devtools/JsonTest.java
@@ -1,0 +1,57 @@
+package com.ligero.devtools;
+
+import com.ligero.beans.BeanGraph;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonTest {
+
+    @Test
+    void escapesStrings() {
+        assertThat(Json.str(null)).isEqualTo("null");
+        assertThat(Json.str("a\"b\\c\nd")).isEqualTo("\"a\\\"b\\\\c\\nd\"");
+        assertThat(Json.str("ctl" + (char) 0x02)).isEqualTo("\"ctl\\u0002\"");
+    }
+
+    @Test
+    void serializesGraphWithStereotypeOverlayAndUnspied() {
+        BeanGraph graph = new BeanGraph(
+            List.of(new BeanGraph.Node("com.x.Repo", "bean"),
+                    new BeanGraph.Node("com.x.Svc", "service")),
+            List.of(new BeanGraph.Edge("com.x.Svc", "com.x.Repo")));
+        String json = Json.graph(graph, Map.of("com.x.Repo", "repository"), List.of("com.x.Cfg"));
+        assertThat(json).isEqualTo(
+            "{\"nodes\":[{\"type\":\"com.x.Repo\",\"stereotype\":\"repository\"},"
+            + "{\"type\":\"com.x.Svc\",\"stereotype\":\"service\"}],"
+            + "\"edges\":[{\"from\":\"com.x.Svc\",\"to\":\"com.x.Repo\"}],"
+            + "\"unspied\":[\"com.x.Cfg\"]}");
+    }
+
+    @Test
+    void serializesTraceWithCalls() {
+        RequestTrace trace = new RequestTrace("abc", "GET", "/items/1");
+        RequestTrace.Call call = trace.enter("StubRepo", "Repo", "repository", "find", "1");
+        call.complete("item-1", null, 42);
+        trace.exit();
+        trace.finish(200);
+
+        String json = Json.trace(trace);
+        assertThat(json)
+            .contains("\"id\":\"abc\"")
+            .contains("\"method\":\"GET\"")
+            .contains("\"path\":\"/items/1\"")
+            .contains("\"status\":200")
+            .contains("\"bean\":\"StubRepo\"")
+            .contains("\"stereotype\":\"repository\"")
+            .contains("\"args\":\"1\"")
+            .contains("\"result\":\"item-1\"")
+            .contains("\"error\":null")
+            .contains("\"durationUs\":42");
+        assertThat(Json.traces(List.of(trace))).isEqualTo("[" + json + "]");
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,5 +13,6 @@ include 'testkit'             // ligero-test: utilidades de testing end-to-end
 include 'openapi'             // ligero-openapi: generación OpenAPI 3 desde las rutas
 include 'metrics-micrometer'  // ligero-metrics-micrometer: adapter MetricsCollector -> Micrometer
 include 'server-jetty'        // ligero-server-jetty: segundo ServerEngine (valida el SPI)
+include 'devtools'            // ligero-devtools: dashboard de desarrollo (grafo de beans + trazas de requests)
 include 'benchmarks'          // JMH (no se publica)
 include 'examples'  // Aplicación de ejemplo (no se publica)


### PR DESCRIPTION
## Resumen

PR ② de la serie (apilado sobre #14 — mergear #14 primero; este PR apunta a esa rama para que el diff quede limpio). El dashboard que motivó las anotaciones: un **debugger visual** en `/ligero/dev`, solo para desarrollo.

```java
Devtools devtools = Devtools.create();

Beans beans = Beans.builder()
    .bind(NameRepo.class,     b -> new JdbcNameRepo(b.get(DataSource.class)))
    .bind(GreetService.class, b -> new DefaultGreetService(b.get(NameRepo.class)))
    .instrument(devtools.recorder())   // espía los beans tipados por interfaz
    .start();

app.beans(beans);
devtools.install(app, beans);          // monta /ligero/dev
```

### Qué se ve en el dashboard

- **Pestaña Beans**: el grafo de dependencias (`beans.graph()`) dibujado en SVG por capas — consumidores a la izquierda, dependencias a la derecha — con cada nodo coloreado por estereotipo (`@Controller` azul, `@Service` verde, `@Repository` naranja…).
- **Pestaña Requests (en vivo, SSE)**: cada request de tu app aparece al instante con método, path, status y duración; al hacer click se despliega la traza por capas:

```
[service]    DefaultGreetService.greet(7) → hello user-7 · 180 µs
    [repository] FixedNameRepo.find(7) → user-7 · 12 µs
```

argumentos, valor de retorno (preview truncado), tiempo por llamada y profundidad de anidamiento; los errores se marcan en rojo con la excepción.

### Cómo funciona

- `DevtoolsRecorder` implementa el hook `BeanDecorator` de #14: envuelve los beans **tipados por interfaz** con `java.lang.reflect.Proxy` (cero bytecode generation). Los beans ligados como clase concreta pasan intactos y el dashboard lo avisa.
- `TraceMiddleware` abre una `RequestTrace` por request (reusa el `requestId` si está el middleware) y publica la traza terminada a un historial acotado (100) + stream SSE. Los endpoints de devtools no se trazan a sí mismos.
- JSON escrito a mano (~100 líneas): el módulo depende **solo de ligero-core**.
- Producción: overhead cero — el módulo no está en el classpath; además `LIGERO_DEVTOOLS=false` convierte `install()` en no-op.

### Extra en core

`Beans.graph()` ahora etiqueta el nodo con el estereotipo de la **clase de implementación** cuando el binding es una interfaz sin anotar (caso típico: `bind(Repo.class, b -> new JdbcRepo(...))` con `@Repository` en `JdbcRepo`).

### Tests

Unitarios (recorder, captura de errores, pass-through fuera de request, JSON) + suite e2e sobre HTTP real que levanta una app por capas y verifica dashboard, API de grafo, traza anidada service→repository y el push SSE en vivo. Build completo en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5iQfCZ8PrTebn22UfjgVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5iQfCZ8PrTebn22UfjgVU)_