### PR TITLE
Feat: módulos de aplicación — LigeroModule + Modules (wiring fuera del startup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] — 0.2.0-SNAPSHOT
 
+### Added (modules)
+- **`LigeroModule` + `Modules.install(...)`**: feature modules Angular-style,
+  without the magic — a module is a plain class declaring its beans and its
+  routes; the app startup just lists modules. All modules share one `Beans`
+  container (cross-module dependencies resolve naturally; duplicates fail
+  fast) and wiring lives in the modules, never in the startup class.
+
 ### Added (devtools)
 - **`ligero-devtools`**: visual debugger for development served at
   `/ligero/dev` — bean dependency graph colored by stereotype plus live

--- a/core/src/main/java/com/ligero/LigeroModule.java
+++ b/core/src/main/java/com/ligero/LigeroModule.java
@@ -1,0 +1,46 @@
+package com.ligero;
+
+import com.ligero.beans.Beans;
+
+/**
+ * A feature module: one vertical slice of the application (its controllers,
+ * services, repositories and routes) declared in a single place, in plain
+ * code. Inspired by Angular modules, minus the magic — a module is just a
+ * class you instantiate and list.
+ *
+ * <pre>{@code
+ * public final class ProductsModule implements LigeroModule {
+ *
+ *     @Override
+ *     public void beans(Beans.Builder builder) {
+ *         builder.bind(ProductRepository.class, b -> new JdbcProductRepository(b.get(DataSource.class)))
+ *                .bind(ProductService.class,    b -> new DefaultProductService(b.get(ProductRepository.class)))
+ *                .bind(ProductController.class, b -> new ProductController(b.get(ProductService.class)));
+ *     }
+ *
+ *     @Override
+ *     public void routes(Ligero app, Beans beans) {
+ *         beans.get(ProductController.class).register(app);
+ *     }
+ * }
+ *
+ * // App startup stays free of wiring:
+ * Modules.install(app, new DbModule(), new ProductsModule(), new UsersModule());
+ * }</pre>
+ *
+ * <p>All modules contribute to a <em>single</em> {@link Beans} container, so
+ * a module can depend on beans bound by another (e.g. {@code DataSource}
+ * from an infrastructure module). Binding the same type twice — even from
+ * different modules — fails fast with a duplicate-binding error.</p>
+ */
+public interface LigeroModule {
+
+    /** Contributes this module's bindings to the shared container. */
+    void beans(Beans.Builder builder);
+
+    /**
+     * Mounts this module's routes. Called after the whole container has been
+     * built and validated, so {@code beans.get(...)} is safe here.
+     */
+    void routes(Ligero app, Beans beans);
+}

--- a/core/src/main/java/com/ligero/Modules.java
+++ b/core/src/main/java/com/ligero/Modules.java
@@ -1,0 +1,41 @@
+package com.ligero;
+
+import com.ligero.beans.BeanDecorator;
+import com.ligero.beans.Beans;
+
+/**
+ * Assembles an application from {@link LigeroModule}s: collects every
+ * module's bindings into one {@link Beans} container, starts it (fail-fast
+ * validation of the whole graph), exposes it to handlers via
+ * {@link Ligero#beans(Beans)} and mounts every module's routes.
+ */
+public final class Modules {
+
+    private Modules() {
+    }
+
+    /** Installs the modules on the app and returns the started container. */
+    public static Beans install(Ligero app, LigeroModule... modules) {
+        return install(app, null, modules);
+    }
+
+    /**
+     * Variant with an instrumentation hook (e.g. the devtools recorder),
+     * applied to every bean of every module.
+     */
+    public static Beans install(Ligero app, BeanDecorator decorator, LigeroModule... modules) {
+        Beans.Builder builder = Beans.builder();
+        for (LigeroModule module : modules) {
+            module.beans(builder);
+        }
+        if (decorator != null) {
+            builder.instrument(decorator);
+        }
+        Beans beans = builder.start();
+        app.beans(beans);
+        for (LigeroModule module : modules) {
+            module.routes(app, beans);
+        }
+        return beans;
+    }
+}

--- a/core/src/test/java/com/ligero/ModulesTest.java
+++ b/core/src/test/java/com/ligero/ModulesTest.java
@@ -1,0 +1,106 @@
+package com.ligero;
+
+import com.ligero.beans.Beans;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ModulesTest {
+
+    record Config(String name) {
+    }
+
+    static class Repo {
+        final Config config;
+
+        Repo(Config config) {
+            this.config = config;
+        }
+    }
+
+    /** Infrastructure module: binds shared beans other modules depend on. */
+    static class InfraModule implements LigeroModule {
+        @Override
+        public void beans(Beans.Builder builder) {
+            builder.bindInstance(Config.class, new Config("test"));
+        }
+
+        @Override
+        public void routes(Ligero app, Beans beans) {
+            // no routes
+        }
+    }
+
+    /** Feature module: depends on a bean bound by InfraModule. */
+    static class FeatureModule implements LigeroModule {
+        final List<String> events;
+
+        FeatureModule(List<String> events) {
+            this.events = events;
+        }
+
+        @Override
+        public void beans(Beans.Builder builder) {
+            builder.bind(Repo.class, b -> new Repo(b.get(Config.class)));
+        }
+
+        @Override
+        public void routes(Ligero app, Beans beans) {
+            events.add("routes:" + beans.get(Repo.class).config.name());
+            app.get("/feature", ctx -> ctx.text("ok"));
+        }
+    }
+
+    @Test
+    void assemblesOneContainerFromAllModulesAndMountsRoutes() {
+        List<String> events = new ArrayList<>();
+        Ligero app = Ligero.create();
+
+        Beans beans = Modules.install(app, new InfraModule(), new FeatureModule(events));
+
+        // cross-module dependency resolved, routes ran with the started container
+        assertThat(events).containsExactly("routes:test");
+        assertThat(beans.get(Repo.class).config).isSameAs(beans.get(Config.class));
+    }
+
+    @Test
+    void appliesTheDecoratorToBeansOfEveryModule() {
+        List<String> decorated = new ArrayList<>();
+        Ligero app = Ligero.create();
+
+        Modules.install(app, new com.ligero.beans.BeanDecorator() {
+            @Override
+            public <T> T decorate(Class<T> type, T bean) {
+                decorated.add(type.getSimpleName());
+                return bean;
+            }
+        }, new InfraModule(), new FeatureModule(new ArrayList<>()));
+
+        assertThat(decorated).containsExactlyInAnyOrder("Config", "Repo");
+    }
+
+    @Test
+    void duplicateBindingsAcrossModulesFailFast() {
+        Ligero app = Ligero.create();
+        LigeroModule duplicate = new InfraModule();
+
+        assertThatThrownBy(() -> Modules.install(app, new InfraModule(), duplicate))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Duplicate binding");
+    }
+
+    @Test
+    void missingCrossModuleDependencyFailsAtInstall() {
+        Ligero app = Ligero.create();
+
+        // FeatureModule sin InfraModule: falta Config
+        assertThatThrownBy(() -> Modules.install(app, new FeatureModule(new ArrayList<>())))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("No binding for");
+    }
+}


### PR DESCRIPTION
## Resumen

PR ③ de la serie (apilado sobre #15 → #14; mergear en ese orden). Módulos de aplicación estilo Angular, sin magia: **el wiring de dependencias vive en una capa propia de clases (los módulos), nunca mezclado con el startup**.

```java
// Un módulo = una feature completa: sus beans y sus rutas, en un solo lugar.
public final class ProductsModule implements LigeroModule {

    @Override
    public void beans(Beans.Builder builder) {
        builder.bind(ProductRepository.class, b -> new JdbcProductRepository(b.get(DataSource.class)))
               .bind(ProductService.class,    b -> new DefaultProductService(b.get(ProductRepository.class)))
               .bind(ProductController.class, b -> new ProductController(b.get(ProductService.class)));
    }

    @Override
    public void routes(Ligero app, Beans beans) {
        beans.get(ProductController.class).register(app);
    }
}

// El startup queda limpio — solo lista módulos:
Modules.install(app, devtools.recorder(), new DbModule(), new ProductsModule(), new UsersModule());
```

### Semántica

- Todos los módulos contribuyen a **un único** contenedor `Beans`: las dependencias entre módulos (p. ej. `DataSource` de un módulo de infraestructura) se resuelven solas.
- Binding duplicado entre módulos → error fail-fast en `install()` (`Duplicate binding`).
- Dependencia faltante entre módulos → `No binding for X (needed by Y)` en el arranque, nunca en un request.
- El decorador (recorder de devtools) se aplica a los beans de **todos** los módulos.
- `routes()` corre después de validar el grafo completo: `beans.get(...)` es seguro ahí.

Es la base para los generadores del CLI (`ligero generate module|controller|service|repository`), que crean el artefacto **y lo registran automáticamente** en su módulo, como el CLI de Angular.

4 tests nuevos; build completo en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5iQfCZ8PrTebn22UfjgVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5iQfCZ8PrTebn22UfjgVU)_