### PR TITLE
Feat: ligero-processor — DI opcional en compilación (genera el wiring explícito)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased] — 0.2.0-SNAPSHOT
 
+### Added (optional compile-time DI)
+- **`ligero-processor`**: an *opt-in* annotation processor that reads the
+  stereotype annotations and `@Provides` static methods at **compile time**
+  and generates the same explicit `bind(...)` wiring you would write by hand
+  — a `LigeroModule` per package plus a single `GeneratedModules.all()`. No
+  classpath scanning, no runtime reflection: the generated code is byte-for-
+  byte what the explicit style produces, so startup and native-image
+  behavior are unchanged. Turn it on by adding the `annotationProcessor`
+  dependency; remove it and you are back to hand-written wiring.
+- Stereotypes gained an optional `as()` attribute (binding key when a class
+  implements several interfaces); new `@Provides` (static bean factories,
+  e.g. a `DataSource`) and `@Inject` (constructor disambiguation) markers,
+  both `SOURCE`-retained (compile-time only).
+
 ### Added (modules)
 - **`LigeroModule` + `Modules.install(...)`**: feature modules Angular-style,
   without the magic — a module is a plain class declaring its beans and its

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ subprojects {
     def coverageMinimums = [core: 0.80, json: 0.70, server: 0.70, auth: 0.70,
                             'template-mustache': 0.60, 'template-freemarker': 0.60, 'template-pebble': 0.60, otel: 0.60, testkit: 0.60, openapi: 0.60,
                             'metrics-micrometer': 0.60, 'server-jetty': 0.50,
-                            devtools: 0.60,
+                            devtools: 0.60, processor: 0.0,
                             examples: 0.0, benchmarks: 0.0]
     jacocoTestCoverageVerification {
         dependsOn test

--- a/core/src/main/java/com/ligero/beans/Inject.java
+++ b/core/src/main/java/com/ligero/beans/Inject.java
@@ -1,0 +1,20 @@
+package com.ligero.beans;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the constructor the optional {@code ligero-processor} should use when
+ * a class has more than one. With a single constructor it is unnecessary —
+ * the processor picks that one.
+ *
+ * <p>Compile-time only, hence {@code SOURCE} retention: the processor emits a
+ * plain {@code new Impl(b.get(...), ...)} call, so nothing about injection
+ * exists at runtime.</p>
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.CONSTRUCTOR)
+public @interface Inject {
+}

--- a/core/src/main/java/com/ligero/beans/Provides.java
+++ b/core/src/main/java/com/ligero/beans/Provides.java
@@ -1,0 +1,31 @@
+package com.ligero.beans;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@code static} method as a factory for the optional
+ * {@code ligero-processor}: the method's return type becomes a binding whose
+ * value is the method's result, letting you contribute beans the processor
+ * can't construct itself — third-party types (a {@code DataSource}),
+ * configuration objects, anything with custom setup.
+ *
+ * <pre>{@code
+ * @Provides
+ * static DataSource dataSource() {
+ *     var ds = new HikariDataSource();
+ *     ds.setJdbcUrl(System.getenv("DB_URL"));
+ *     return ds;
+ * }
+ * }</pre>
+ *
+ * <p>Compile-time only (the processor turns it into a plain
+ * {@code bind(DataSource.class, b -> EnclosingClass.dataSource())}), so it has
+ * {@code SOURCE} retention and no runtime footprint.</p>
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.METHOD)
+public @interface Provides {
+}

--- a/core/src/main/java/com/ligero/beans/stereotype/Component.java
+++ b/core/src/main/java/com/ligero/beans/stereotype/Component.java
@@ -7,10 +7,17 @@ import java.lang.annotation.Target;
 
 /**
  * Stereotype marker for the dependency dashboard and diagnostics. Pure
- * metadata: wiring stays in explicit {@code bind(...)} lambdas — this
- * annotation never triggers scanning or reflection-based injection.
+ * metadata at runtime: wiring stays in explicit {@code bind(...)} lambdas —
+ * this annotation never triggers scanning or reflection-based injection.
+ *
+ * <p>The optional {@code ligero-processor} reads it at <em>compile time</em>
+ * to generate those same explicit bindings (still no runtime reflection);
+ * {@link #as()} picks the binding key when several interfaces are implemented.</p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Component {
+
+    /** Binding key for the optional processor; defaults to the single implemented interface (or the class itself). */
+    Class<?> as() default Void.class;
 }

--- a/core/src/main/java/com/ligero/beans/stereotype/Controller.java
+++ b/core/src/main/java/com/ligero/beans/stereotype/Controller.java
@@ -7,10 +7,17 @@ import java.lang.annotation.Target;
 
 /**
  * Stereotype marker for the dependency dashboard and diagnostics. Pure
- * metadata: wiring stays in explicit {@code bind(...)} lambdas — this
- * annotation never triggers scanning or reflection-based injection.
+ * metadata at runtime: wiring stays in explicit {@code bind(...)} lambdas —
+ * this annotation never triggers scanning or reflection-based injection.
+ *
+ * <p>The optional {@code ligero-processor} reads it at <em>compile time</em>
+ * to generate those same explicit bindings (still no runtime reflection);
+ * {@link #as()} picks the binding key when several interfaces are implemented.</p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Controller {
+
+    /** Binding key for the optional processor; defaults to the single implemented interface (or the class itself). */
+    Class<?> as() default Void.class;
 }

--- a/core/src/main/java/com/ligero/beans/stereotype/Repository.java
+++ b/core/src/main/java/com/ligero/beans/stereotype/Repository.java
@@ -7,10 +7,17 @@ import java.lang.annotation.Target;
 
 /**
  * Stereotype marker for the dependency dashboard and diagnostics. Pure
- * metadata: wiring stays in explicit {@code bind(...)} lambdas — this
- * annotation never triggers scanning or reflection-based injection.
+ * metadata at runtime: wiring stays in explicit {@code bind(...)} lambdas —
+ * this annotation never triggers scanning or reflection-based injection.
+ *
+ * <p>The optional {@code ligero-processor} reads it at <em>compile time</em>
+ * to generate those same explicit bindings (still no runtime reflection);
+ * {@link #as()} picks the binding key when several interfaces are implemented.</p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Repository {
+
+    /** Binding key for the optional processor; defaults to the single implemented interface (or the class itself). */
+    Class<?> as() default Void.class;
 }

--- a/core/src/main/java/com/ligero/beans/stereotype/Service.java
+++ b/core/src/main/java/com/ligero/beans/stereotype/Service.java
@@ -7,10 +7,17 @@ import java.lang.annotation.Target;
 
 /**
  * Stereotype marker for the dependency dashboard and diagnostics. Pure
- * metadata: wiring stays in explicit {@code bind(...)} lambdas — this
- * annotation never triggers scanning or reflection-based injection.
+ * metadata at runtime: wiring stays in explicit {@code bind(...)} lambdas —
+ * this annotation never triggers scanning or reflection-based injection.
+ *
+ * <p>The optional {@code ligero-processor} reads it at <em>compile time</em>
+ * to generate those same explicit bindings (still no runtime reflection);
+ * {@link #as()} picks the binding key when several interfaces are implemented.</p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Service {
+
+    /** Binding key for the optional processor; defaults to the single implemented interface (or the class itself). */
+    Class<?> as() default Void.class;
 }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -1,0 +1,12 @@
+description = 'Ligero optional annotation processor: generates explicit bind() wiring at compile time (no runtime reflection)'
+
+dependencies {
+    // Needs the stereotype/@Provides annotations and the types the generated
+    // code references (Beans, Ligero, LigeroModule) on the compile classpath.
+    implementation project(':core')
+
+    testImplementation project(':core')
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly libs.junit.launcher
+    testImplementation libs.assertj.core
+}

--- a/processor/src/main/java/com/ligero/processor/LigeroProcessor.java
+++ b/processor/src/main/java/com/ligero/processor/LigeroProcessor.java
@@ -1,0 +1,335 @@
+package com.ligero.processor;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.tools.Diagnostic;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Optional Ligero DI: reads the stereotype annotations
+ * ({@code @Component/@Service/@Repository/@Controller}) and {@code @Provides}
+ * static methods at <em>compile time</em> and generates the same explicit
+ * {@code bind(...)} wiring you would otherwise write by hand — so there is no
+ * classpath scanning and no runtime reflection.
+ *
+ * <p>Per Java package it emits {@code <pkg>.LigeroGeneratedModule} (a
+ * {@link com.ligero.LigeroModule}) with the package's bindings and, for
+ * controllers exposing {@code register(Ligero)}, their route mounting. It
+ * also emits a single {@code com.ligero.generated.GeneratedModules.all()}
+ * returning every generated module, so an app starts with:</p>
+ *
+ * <pre>{@code Modules.install(app, GeneratedModules.all());}</pre>
+ */
+@SupportedAnnotationTypes({
+    "com.ligero.beans.stereotype.Component",
+    "com.ligero.beans.stereotype.Service",
+    "com.ligero.beans.stereotype.Repository",
+    "com.ligero.beans.stereotype.Controller",
+    "com.ligero.beans.Provides",
+})
+@SupportedSourceVersion(SourceVersion.RELEASE_21)
+public final class LigeroProcessor extends AbstractProcessor {
+
+    private static final Set<String> STEREOTYPES = Set.of(
+        "com.ligero.beans.stereotype.Component",
+        "com.ligero.beans.stereotype.Service",
+        "com.ligero.beans.stereotype.Repository",
+        "com.ligero.beans.stereotype.Controller");
+    private static final String PROVIDES = "com.ligero.beans.Provides";
+    private static final String LIGERO = "com.ligero.Ligero";
+    private static final String GENERATED_MODULE = "LigeroGeneratedModule";
+    private static final String AGGREGATOR = "com.ligero.generated.GeneratedModules";
+
+    /** package name -> its collected bindings, gathered across rounds. */
+    private final Map<String, PackageModel> packages = new LinkedHashMap<>();
+    private boolean generated;
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (String stereotype : STEREOTYPES) {
+            TypeElement annotation = elements().getTypeElement(stereotype);
+            if (annotation != null) {
+                for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
+                    handleBean((TypeElement) element, stereotype);
+                }
+            }
+        }
+        TypeElement provides = elements().getTypeElement(PROVIDES);
+        if (provides != null) {
+            for (Element element : roundEnv.getElementsAnnotatedWith(provides)) {
+                handleProvides((ExecutableElement) element);
+            }
+        }
+        // Generate as soon as the annotated classes are in hand (they all arrive
+        // in the first round). Emitting early — not in the processingOver round —
+        // lets hand-written code reference the generated GeneratedModules.
+        if (!generated && !packages.isEmpty()) {
+            generated = true;
+            writeSources();
+        }
+        return false;
+    }
+
+    // ---------------------------------------------------------------- collect
+
+    private void handleBean(TypeElement type, String stereotype) {
+        if (type.getModifiers().contains(Modifier.ABSTRACT)) {
+            error(type, stereotype + " must be a concrete class");
+            return;
+        }
+        String pkg = packageOf(type);
+        if (pkg.isEmpty()) {
+            error(type, "Ligero's processor needs annotated classes to live in a named package");
+            return;
+        }
+        ExecutableElement ctor = selectConstructor(type);
+        if (ctor == null) {
+            return; // error already reported
+        }
+        List<String> params = new ArrayList<>();
+        for (VariableElement param : ctor.getParameters()) {
+            String name = qualifiedOf(param.asType());
+            if (name == null) {
+                error(type, "constructor parameter '" + param.getSimpleName()
+                    + "' is not an injectable type — provide it with @Provides or an explicit bind()");
+                return;
+            }
+            params.add(name);
+        }
+        String key = bindingKey(type, stereotype);
+        String impl = type.getQualifiedName().toString();
+        boolean hasRoutes = hasRegisterMethod(type);
+        packages.computeIfAbsent(pkg, PackageModel::new)
+            .beans.add(new BeanBinding(key, impl, params, hasRoutes));
+    }
+
+    private void handleProvides(ExecutableElement method) {
+        if (!method.getModifiers().contains(Modifier.STATIC)) {
+            error(method, "@Provides methods must be static");
+            return;
+        }
+        String returnType = qualifiedOf(method.getReturnType());
+        if (returnType == null) {
+            error(method, "@Provides method must return an injectable type");
+            return;
+        }
+        TypeElement enclosing = (TypeElement) method.getEnclosingElement();
+        String pkg = packageOf(enclosing);
+        packages.computeIfAbsent(pkg, PackageModel::new).provides.add(new ProvidesBinding(
+            returnType, enclosing.getQualifiedName().toString(), method.getSimpleName().toString()));
+    }
+
+    /** as() override, else the single implemented interface, else the class itself. */
+    private String bindingKey(TypeElement type, String stereotype) {
+        String explicit = asAttribute(type, stereotype);
+        if (explicit != null && !explicit.equals("java.lang.Void")) {
+            return explicit;
+        }
+        List<? extends TypeMirror> interfaces = type.getInterfaces();
+        if (interfaces.size() == 1) {
+            String only = qualifiedOf(interfaces.get(0));
+            if (only != null) {
+                return only;
+            }
+        }
+        return type.getQualifiedName().toString();
+    }
+
+    private String asAttribute(TypeElement type, String stereotype) {
+        for (AnnotationMirror mirror : type.getAnnotationMirrors()) {
+            if (!mirror.getAnnotationType().toString().equals(stereotype)) {
+                continue;
+            }
+            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> e
+                    : mirror.getElementValues().entrySet()) {
+                if (e.getKey().getSimpleName().contentEquals("as")) {
+                    return qualifiedOf((TypeMirror) e.getValue().getValue());
+                }
+            }
+        }
+        return null;
+    }
+
+    private ExecutableElement selectConstructor(TypeElement type) {
+        List<ExecutableElement> ctors = ElementFilter.constructorsIn(type.getEnclosedElements());
+        if (ctors.size() == 1) {
+            return ctors.get(0);
+        }
+        List<ExecutableElement> injected = new ArrayList<>();
+        for (ExecutableElement ctor : ctors) {
+            if (hasAnnotation(ctor, "com.ligero.beans.Inject")) {
+                injected.add(ctor);
+            }
+        }
+        if (injected.size() == 1) {
+            return injected.get(0);
+        }
+        error(type, "has " + ctors.size() + " constructors — annotate one with @Inject "
+            + "(com.ligero.beans.Inject) or use an explicit bind()");
+        return null;
+    }
+
+    private boolean hasRegisterMethod(TypeElement type) {
+        for (ExecutableElement method : ElementFilter.methodsIn(type.getEnclosedElements())) {
+            if (method.getSimpleName().contentEquals("register")
+                    && method.getParameters().size() == 1
+                    && LIGERO.equals(qualifiedOf(method.getParameters().get(0).asType()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ----------------------------------------------------------------- emit
+
+    private void writeSources() {
+        List<String> moduleClasses = new ArrayList<>();
+        for (PackageModel model : packages.values()) {
+            if (model.beans.isEmpty() && model.provides.isEmpty()) {
+                continue;
+            }
+            String fqcn = model.pkg + "." + GENERATED_MODULE;
+            writeModule(fqcn, model);
+            moduleClasses.add(fqcn);
+        }
+        writeAggregator(moduleClasses);
+    }
+
+    private void writeModule(String fqcn, PackageModel model) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("package ").append(model.pkg).append(";\n\n");
+        sb.append("// Generated by ligero-processor. Do not edit.\n");
+        sb.append("public final class ").append(GENERATED_MODULE)
+          .append(" implements com.ligero.LigeroModule {\n\n");
+
+        sb.append("    @Override\n");
+        sb.append("    public void beans(com.ligero.beans.Beans.Builder builder) {\n");
+        for (ProvidesBinding provide : model.provides) {
+            sb.append("        builder.bind(").append(provide.returnType).append(".class, b -> ")
+              .append(provide.enclosing).append('.').append(provide.method).append("());\n");
+        }
+        for (BeanBinding bean : model.beans) {
+            sb.append("        builder.bind(").append(bean.key).append(".class, b -> new ")
+              .append(bean.impl).append('(');
+            for (int i = 0; i < bean.params.size(); i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                sb.append("b.get(").append(bean.params.get(i)).append(".class)");
+            }
+            sb.append("));\n");
+        }
+        sb.append("    }\n\n");
+
+        sb.append("    @Override\n");
+        sb.append("    public void routes(com.ligero.Ligero app, com.ligero.beans.Beans beans) {\n");
+        for (BeanBinding bean : model.beans) {
+            if (bean.hasRoutes) {
+                sb.append("        beans.get(").append(bean.key).append(".class).register(app);\n");
+            }
+        }
+        sb.append("    }\n");
+        sb.append("}\n");
+
+        write(fqcn, sb.toString());
+    }
+
+    private void writeAggregator(List<String> moduleClasses) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("package com.ligero.generated;\n\n");
+        sb.append("// Generated by ligero-processor. Do not edit.\n");
+        sb.append("public final class GeneratedModules {\n\n");
+        sb.append("    private GeneratedModules() {\n    }\n\n");
+        sb.append("    /** Every module generated from your annotated classes, in one array. */\n");
+        sb.append("    public static com.ligero.LigeroModule[] all() {\n");
+        sb.append("        return new com.ligero.LigeroModule[] {\n");
+        for (String moduleClass : moduleClasses) {
+            sb.append("            new ").append(moduleClass).append("(),\n");
+        }
+        sb.append("        };\n");
+        sb.append("    }\n");
+        sb.append("}\n");
+        write(AGGREGATOR, sb.toString());
+    }
+
+    private void write(String fqcn, String source) {
+        try (Writer writer = processingEnv.getFiler().createSourceFile(fqcn).openWriter()) {
+            writer.write(source);
+        } catch (IOException e) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+                "ligero-processor could not write " + fqcn + ": " + e.getMessage());
+        }
+    }
+
+    // --------------------------------------------------------------- helpers
+
+    private String qualifiedOf(TypeMirror type) {
+        if (type.getKind() == TypeKind.DECLARED) {
+            Element element = ((DeclaredType) type).asElement();
+            if (element instanceof TypeElement typeElement) {
+                return typeElement.getQualifiedName().toString();
+            }
+        }
+        return null;
+    }
+
+    private String packageOf(TypeElement type) {
+        return elements().getPackageOf(type).getQualifiedName().toString();
+    }
+
+    private boolean hasAnnotation(Element element, String annotationName) {
+        for (AnnotationMirror mirror : element.getAnnotationMirrors()) {
+            if (mirror.getAnnotationType().toString().equals(annotationName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private javax.lang.model.util.Elements elements() {
+        return processingEnv.getElementUtils();
+    }
+
+    private void error(Element element, String message) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
+            "@" + element.getSimpleName() + ": " + message, element);
+    }
+
+    // ----------------------------------------------------------------- models
+
+    private static final class PackageModel {
+        final String pkg;
+        final List<BeanBinding> beans = new ArrayList<>();
+        final List<ProvidesBinding> provides = new ArrayList<>();
+
+        PackageModel(String pkg) {
+            this.pkg = pkg;
+        }
+    }
+
+    private record BeanBinding(String key, String impl, List<String> params, boolean hasRoutes) {
+    }
+
+    private record ProvidesBinding(String returnType, String enclosing, String method) {
+    }
+}

--- a/processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+com.ligero.processor.LigeroProcessor

--- a/processor/src/test/java/com/ligero/processor/LigeroProcessorTest.java
+++ b/processor/src/test/java/com/ligero/processor/LigeroProcessorTest.java
@@ -1,0 +1,127 @@
+package com.ligero.processor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Compiles a sample layered package with the processor attached and checks
+ * that (a) the whole thing compiles — proving the generated bindings are
+ * valid Java against the real core types — and (b) the generated sources
+ * contain the expected explicit {@code bind(...)} wiring.
+ */
+class LigeroProcessorTest {
+
+    @TempDir
+    Path dir;
+
+    @Test
+    void generatesExplicitBindingsAndAggregatorThatCompile() throws IOException {
+        Path src = Files.createDirectories(dir.resolve("src/demo"));
+        write(src, "Repo.java", "package demo; public interface Repo {}");
+        write(src, "JdbcRepo.java", """
+            package demo;
+            import com.ligero.beans.stereotype.Repository;
+            import javax.sql.DataSource;
+            @Repository public class JdbcRepo implements Repo {
+                public JdbcRepo(DataSource ds) {}
+            }""");
+        write(src, "Svc.java", "package demo; public interface Svc {}");
+        write(src, "DefaultSvc.java", """
+            package demo;
+            import com.ligero.beans.stereotype.Service;
+            @Service public class DefaultSvc implements Svc {
+                public DefaultSvc(Repo repo) {}
+            }""");
+        write(src, "Ctrl.java", """
+            package demo;
+            import com.ligero.Ligero;
+            import com.ligero.beans.stereotype.Controller;
+            @Controller public class Ctrl {
+                public Ctrl(Svc svc) {}
+                public void register(Ligero app) {}
+            }""");
+        write(src, "Config.java", """
+            package demo;
+            import com.ligero.beans.Provides;
+            import javax.sql.DataSource;
+            public class Config {
+                @Provides static DataSource ds() { return null; }
+            }""");
+
+        Path gen = Files.createDirectories(dir.resolve("generated"));
+        Path out = Files.createDirectories(dir.resolve("classes"));
+
+        boolean ok = compileWithProcessor(src, gen, out);
+        assertThat(ok).as("sample + generated code compiles").isTrue();
+
+        String module = Files.readString(gen.resolve("demo/LigeroGeneratedModule.java"));
+        assertThat(module)
+            .contains("implements com.ligero.LigeroModule")
+            .contains("builder.bind(javax.sql.DataSource.class, b -> demo.Config.ds());")
+            .contains("builder.bind(demo.Repo.class, b -> new demo.JdbcRepo(b.get(javax.sql.DataSource.class)));")
+            .contains("builder.bind(demo.Svc.class, b -> new demo.DefaultSvc(b.get(demo.Repo.class)));")
+            .contains("builder.bind(demo.Ctrl.class, b -> new demo.Ctrl(b.get(demo.Svc.class)));")
+            .contains("beans.get(demo.Ctrl.class).register(app);");
+
+        String aggregator = Files.readString(gen.resolve("com/ligero/generated/GeneratedModules.java"));
+        assertThat(aggregator)
+            .contains("public static com.ligero.LigeroModule[] all()")
+            .contains("new demo.LigeroGeneratedModule()");
+    }
+
+    @Test
+    void ambiguousConstructorIsACompileError() throws IOException {
+        Path src = Files.createDirectories(dir.resolve("src/demo"));
+        write(src, "Two.java", """
+            package demo;
+            import com.ligero.beans.stereotype.Service;
+            @Service public class Two {
+                public Two() {}
+                public Two(String a) {}
+            }""");
+        Path gen = Files.createDirectories(dir.resolve("generated"));
+        Path out = Files.createDirectories(dir.resolve("classes"));
+
+        StringWriter diagnostics = new StringWriter();
+        boolean ok = compileWithProcessor(src, gen, out, diagnostics);
+        assertThat(ok).isFalse();
+        assertThat(diagnostics.toString()).contains("constructors").contains("@Inject");
+    }
+
+    private boolean compileWithProcessor(Path srcDir, Path genDir, Path outDir) throws IOException {
+        return compileWithProcessor(srcDir, genDir, outDir, new StringWriter());
+    }
+
+    private boolean compileWithProcessor(Path srcDir, Path genDir, Path outDir, StringWriter out)
+            throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        StandardJavaFileManager fm = compiler.getStandardFileManager(null, null, null);
+        List<Path> sources;
+        try (var stream = Files.list(srcDir)) {
+            sources = stream.filter(p -> p.toString().endsWith(".java")).toList();
+        }
+        Iterable<? extends JavaFileObject> units = fm.getJavaFileObjectsFromPaths(sources);
+        List<String> options = List.of(
+            "-processor", "com.ligero.processor.LigeroProcessor",
+            "-classpath", System.getProperty("java.class.path"),
+            "-s", genDir.toString(),
+            "-d", outDir.toString());
+        return compiler.getTask(out, fm, null, options, null, units).call();
+    }
+
+    private static void write(Path dir, String name, String content) throws IOException {
+        Files.writeString(dir.resolve(name), content);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,5 +14,6 @@ include 'openapi'             // ligero-openapi: generación OpenAPI 3 desde las
 include 'metrics-micrometer'  // ligero-metrics-micrometer: adapter MetricsCollector -> Micrometer
 include 'server-jetty'        // ligero-server-jetty: segundo ServerEngine (valida el SPI)
 include 'devtools'            // ligero-devtools: dashboard de desarrollo (grafo de beans + trazas de requests)
+include 'processor'          // ligero-processor: DI opcional en compilación (genera los bind() explícitos)
 include 'benchmarks'          // JMH (no se publica)
 include 'examples'  // Aplicación de ejemplo (no se publica)


### PR DESCRIPTION
## Resumen

PR ④ de la serie (apilado sobre #16 → #15 → #14; mergear en ese orden). Un annotation processor **opcional** para quien quiere menos boilerplate **sin pagar reflexión en runtime**. La forma explícita sigue siendo el default; esto es un extra que se prende con una dependencia.

**La idea:** el processor es un "tipeador" — lee los estereotipos y los `@Provides` **en compilación** y genera **los mismos `bind(...)` explícitos** que escribirías a mano. Cero scanning, cero reflexión en runtime.

### Antes (sin processor) vs después (con processor)

```java
// Anotás las clases (ya lo hacías) …
@Repository class JdbcProductRepository implements ProductRepository { JdbcProductRepository(DataSource ds) {…} }
@Service    class DefaultProductService implements ProductService    { DefaultProductService(ProductRepository r) {…} }
@Controller class ProductController { ProductController(ProductService s) {…}  public void register(Ligero app){…} }

// … y en vez de escribir el módulo con bind() a mano:
Modules.install(app, GeneratedModules.all());   // ← todo el wiring lo generó el processor
```

### Lo que genera (byte por byte lo que escribirías a mano)

```java
// GENERADO — <pkg>/LigeroGeneratedModule.java
public final class LigeroGeneratedModule implements com.ligero.LigeroModule {
    public void beans(com.ligero.beans.Beans.Builder builder) {
        builder.bind(ProductRepository.class, b -> new InMemoryProductRepository());
        builder.bind(ProductService.class,    b -> new DefaultProductService(b.get(ProductRepository.class)));
        builder.bind(ProductController.class, b -> new ProductController(b.get(ProductService.class)));
    }
    public void routes(com.ligero.Ligero app, com.ligero.beans.Beans beans) {
        beans.get(ProductController.class).register(app);
    }
}
// + com.ligero.generated.GeneratedModules.all()
```

Como es el mismo `bind`, **el arranque y el comportamiento en imagen nativa no cambian**.

## Cómo se activa (opcional/configurable)

Una línea en `build.gradle`:

```groovy
annotationProcessor 'com.ligero:ligero-processor:0.2.0-SNAPSHOT'  // presente = genera; ausente = wiring a mano
```

| Knob | Cómo |
|---|---|
| Clave de binding | la única interfaz implementada; varias → `@Service(as = ProductService.class)`; ninguna → la clase (típico `@Controller`) |
| Tipos de terceros (DataSource, config) | `@Provides static DataSource ds() {…}` |
| Rutas de un `@Controller` | si tiene `register(Ligero)`, el módulo generado lo llama |
| Constructor ambiguo | 1 constructor, o `@Inject` → si no, **error en compilación** con mensaje claro |
| Mezclar a mano + generado | `Modules.install(app, new InfraModule(), GeneratedModules.all())` |

## Cambios en core

- Estereotipos: atributo opcional `as()` (metadata en runtime como siempre).
- Nuevos markers `@Provides` (factories estáticas) y `@Inject` (desambiguación), ambos `SOURCE` (solo compilación).

## Tests / verificación

- Tests compilan un paquete por capas con el processor y verifican que **todo compila** (los binds generados son Java válido contra el core real) y que las fuentes generadas contienen los `bind` esperados; el constructor ambiguo **falla en compilación**.
- Verificado e2e: un proyecto cableado **solo** con anotaciones + `GeneratedModules.all()` compila, arranca y sirve controller→service→repository. Build completo en verde.

Próximo en la serie: flag `ligero new --wiring=processor` en el CLI y la doc con las dos formas lado a lado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5iQfCZ8PrTebn22UfjgVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5iQfCZ8PrTebn22UfjgVU)_